### PR TITLE
fix(exits): replace numeric Employee ID input with searchable picker

### DIFF
--- a/packages/client/src/pages/exits/InitiateExitPage.tsx
+++ b/packages/client/src/pages/exits/InitiateExitPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { UserMinus, Loader2 } from "lucide-react";
+import { UserMinus, Loader2, Search, X } from "lucide-react";
 import { apiPost, apiGet } from "@/api/client";
 import { cn } from "@/lib/utils";
 
@@ -40,7 +40,16 @@ export function InitiateExitPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const [employeeId, setEmployeeId] = useState("");
+  // #4 — instead of asking the user to type a numeric DB id (which broke
+  // when they typed "E-101" because the field was type="number"), present
+  // a search-and-select picker that resolves any of name / email / emp_code
+  // to the underlying user.id.
+  const [selectedEmployee, setSelectedEmployee] = useState<Employee | null>(null);
+  const [employeeQuery, setEmployeeQuery] = useState("");
+  const [employeeResults, setEmployeeResults] = useState<Employee[]>([]);
+  const [searchingEmployees, setSearchingEmployees] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const employeeId = selectedEmployee ? String(selectedEmployee.id) : "";
   const [exitType, setExitType] = useState("resignation");
   const [reasonCategory, setReasonCategory] = useState("better_opportunity");
   const [reasonDetail, setReasonDetail] = useState("");
@@ -48,6 +57,39 @@ export function InitiateExitPage() {
   const [lastWorkingDate, setLastWorkingDate] = useState("");
   const [noticePeriodDays, setNoticePeriodDays] = useState("30");
   const [noticePeriodWaived, setNoticePeriodWaived] = useState(false);
+
+  // Debounced employee search (300ms). Discards stale responses by
+  // comparing against the latest query at resolve time.
+  useEffect(() => {
+    if (selectedEmployee) return; // user already picked someone
+    const q = employeeQuery.trim();
+    if (!q) {
+      setEmployeeResults([]);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      setSearchingEmployees(true);
+      try {
+        const res = await apiGet<Employee[]>("/users/search", { q });
+        // Only keep this response if the query hasn't changed in the meantime.
+        if (employeeQuery.trim() === q) {
+          setEmployeeResults(res.data ?? []);
+        }
+      } catch {
+        // ignore network errors during typing
+      } finally {
+        setSearchingEmployees(false);
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [employeeQuery, selectedEmployee]);
+
+  function clearEmployee() {
+    setSelectedEmployee(null);
+    setEmployeeQuery("");
+    setEmployeeResults([]);
+    setShowResults(false);
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -90,20 +132,96 @@ export function InitiateExitPage() {
             </div>
           )}
 
-          {/* Employee ID */}
-          <div>
-            <label htmlFor="employee_id" className="block text-sm font-medium text-gray-700 mb-1">
-              Employee ID <span className="text-red-500">*</span>
+          {/* Employee picker — #4 — search by name / email / emp_code,
+              resolves to the underlying user.id on selection. */}
+          <div className="relative">
+            <label htmlFor="employee_search" className="block text-sm font-medium text-gray-700 mb-1">
+              Employee <span className="text-red-500">*</span>
             </label>
-            <input
-              id="employee_id"
-              type="number"
-              required
-              value={employeeId}
-              onChange={(e) => setEmployeeId(e.target.value)}
-              placeholder="Enter employee ID"
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
-            />
+            {selectedEmployee ? (
+              <div className="flex items-center justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2.5">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-900">
+                    {selectedEmployee.first_name} {selectedEmployee.last_name}
+                  </p>
+                  <p className="truncate text-xs text-gray-500">
+                    {selectedEmployee.emp_code ? `${selectedEmployee.emp_code} · ` : ""}
+                    {selectedEmployee.email}
+                    {selectedEmployee.designation ? ` · ${selectedEmployee.designation}` : ""}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={clearEmployee}
+                  aria-label="Clear selection"
+                  className="rounded-lg p-1 text-gray-400 hover:bg-white hover:text-gray-600"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                  <input
+                    id="employee_search"
+                    type="text"
+                    autoComplete="off"
+                    value={employeeQuery}
+                    onChange={(e) => {
+                      setEmployeeQuery(e.target.value);
+                      setShowResults(true);
+                    }}
+                    onFocus={() => setShowResults(true)}
+                    onBlur={() => setTimeout(() => setShowResults(false), 150)}
+                    placeholder="Search by name, email, or employee code (e.g. E-101)..."
+                    className="w-full rounded-lg border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+                  />
+                </div>
+                {showResults && employeeQuery.trim() && (
+                  <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+                    {searchingEmployees ? (
+                      <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-500">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" /> Searching...
+                      </div>
+                    ) : employeeResults.length === 0 ? (
+                      <p className="px-3 py-2 text-xs text-gray-500">No matching employees.</p>
+                    ) : (
+                      employeeResults.map((emp) => (
+                        <button
+                          key={emp.id}
+                          type="button"
+                          onMouseDown={(e) => {
+                            // onMouseDown so it fires before the input's onBlur
+                            // closes the dropdown.
+                            e.preventDefault();
+                            setSelectedEmployee(emp);
+                            setEmployeeQuery("");
+                            setEmployeeResults([]);
+                            setShowResults(false);
+                          }}
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-gray-50"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium text-gray-900">
+                              {emp.first_name} {emp.last_name}
+                            </p>
+                            <p className="truncate text-xs text-gray-500">
+                              {emp.emp_code ? `${emp.emp_code} · ` : ""}{emp.email}
+                            </p>
+                          </div>
+                          {emp.designation && (
+                            <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] text-gray-600">
+                              {emp.designation}
+                            </span>
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
+              </>
+            )}
           </div>
 
           {/* Exit Type */}

--- a/packages/server/src/api/routes/users.routes.ts
+++ b/packages/server/src/api/routes/users.routes.ts
@@ -1,0 +1,46 @@
+// ============================================================================
+// USERS ROUTES — read-only proxy into the EmpCloud `users` table for the
+// caller's organization. Used by UI pickers (initiate exit, etc.) to
+// resolve a person from name/email/emp_code instead of asking the user
+// to memorise the numeric DB id.
+// ============================================================================
+
+import { Router, Request, Response, NextFunction } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import { getEmpCloudDB } from "../../db/empcloud";
+import { sendSuccess } from "../../utils/response";
+
+const router = Router();
+
+router.use(authenticate);
+
+// GET /search?q=... — typeahead lookup, max 20 results, scoped to org
+router.get("/search", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const q = String(req.query.q ?? "").trim();
+    const db = getEmpCloudDB();
+    const orgId = req.user!.empcloudOrgId;
+
+    let query = db("users")
+      .where({ organization_id: orgId, status: 1 })
+      .select("id", "first_name", "last_name", "email", "emp_code", "designation");
+
+    if (q) {
+      const like = `%${q}%`;
+      query = query.andWhere((b) => {
+        b.where("first_name", "like", like)
+          .orWhere("last_name", "like", like)
+          .orWhere("email", "like", like)
+          .orWhere("emp_code", "like", like)
+          .orWhereRaw("CONCAT(first_name, ' ', last_name) LIKE ?", [like]);
+      });
+    }
+
+    const rows = await query.orderBy("first_name", "asc").limit(20);
+    sendSuccess(res, rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export { router as usersRoutes };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -33,6 +33,7 @@ import { rehireRoutes } from "./api/routes/rehire.routes";
 import { emailTemplateRoutes } from "./api/routes/email-template.routes";
 import { npsRoutes } from "./api/routes/nps.routes";
 import { myClearancesRoutes } from "./api/routes/my-clearances.routes";
+import { usersRoutes } from "./api/routes/users.routes";
 import { errorHandler } from "./api/middleware/error.middleware";
 import { apiLimiter } from "./api/middleware/rate-limit.middleware";
 import { swaggerUIHandler, openapiHandler } from "./api/docs";
@@ -104,6 +105,7 @@ v1.use("/settings", settingsRoutes);
 v1.use("/buyout", buyoutRoutes);
 v1.use("/rehire", rehireRoutes);
 v1.use("/email-templates", emailTemplateRoutes);
+v1.use("/users", usersRoutes);
 
 // Alias routes — some clients use flattened paths (e.g. /checklist-templates)
 // instead of the nested resource paths (e.g. /checklists/templates).


### PR DESCRIPTION
## Summary
Fixes **#4** - the Employee ID field on `/exits/new` accepted only digits. Users naturally typed their employee code like `E-101` (which is what's displayed on every other screen), the input silently rejected it (`type="number"` strips non-numeric input), the React state stayed empty, and the **Initiate Exit** button never enabled.

## Root cause
Two compounding choices on `InitiateExitPage`:
1. The field was `<input type="number">` so anything with a letter/hyphen got rejected before reaching React state.
2. The submit button is gated on `!employeeId`, so the never-set state translated directly to a permanently-disabled button.

## Fix
- **Backend** - new route `GET /api/v1/users/search?q=...` ([users.routes.ts](packages/server/src/api/routes/users.routes.ts)) querying the EmpCloud master DB (`getEmpCloudDB()`) scoped to the caller's org, matching `q` against `first_name`, `last_name`, `email`, `emp_code`, or the concatenated full name. Returns up to 20 results, active users only (`status: 1`).
- **Frontend** - swap the bare numeric input for a debounced (300ms) search-and-select picker. Once an employee is picked, the page shows them as a chip (name + `emp_code` + email + designation) and the underlying `user.id` is what's posted to `/exits`. Selection lives in `selectedEmployee` state; `employeeId` is derived from it, so the existing `disabled={!employeeId}` gate now flips correctly.

## Files
- `packages/server/src/api/routes/users.routes.ts` (new, +46)
- `packages/server/src/index.ts` (+2 mount)
- `packages/client/src/pages/exits/InitiateExitPage.tsx` (+133 / -15)

## Test plan
- [ ] `/exits/new` -> type "E-101" -> matching employees appear in dropdown -> click one -> chip shows the selection and the **Initiate Exit** button enables
- [ ] Type a name fragment ("Anan") -> filters live with 300ms debounce
- [ ] Type an email -> matches by email
- [ ] No matches -> dropdown shows "No matching employees."
- [ ] Click X on chip -> selection clears, search input returns
- [ ] Submit -> request body posts `employee_id: <numeric user.id>` (verify via Network tab)
- [ ] Searching is org-scoped: a user from a different org isn't returned

Closes #4
