### PR TITLE
fix(letters): expose Manage Templates entry point + empty-state hint

### DIFF
--- a/packages/client/src/pages/letters/GeneratedLettersPage.tsx
+++ b/packages/client/src/pages/letters/GeneratedLettersPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, Link } from "react-router-dom";
 import {
   FileSignature,
   Download,
@@ -7,6 +7,7 @@ import {
   Loader2,
   FileText,
   Plus,
+  Settings2,
 } from "lucide-react";
 import { apiGet, apiPost } from "@/api/client";
 import { api } from "@/api/client";
@@ -112,15 +113,27 @@ export function GeneratedLettersPage() {
           <h1 className="text-2xl font-bold text-gray-900">Generated Letters</h1>
           <p className="mt-1 text-sm text-gray-500">View, download, and send generated exit letters.</p>
         </div>
-        {exitId && (
-          <button
-            onClick={() => setShowGenerate(!showGenerate)}
-            className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700"
+        <div className="flex items-center gap-2">
+          {/* "Manage templates" — letter templates live at /letters/templates
+              but there was no UI link to it from anywhere, so users couldn't
+              find the create-template flow. */}
+          <Link
+            to="/letters/templates"
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
-            <Plus className="h-4 w-4" />
-            Generate Letter
-          </button>
-        )}
+            <Settings2 className="h-4 w-4" />
+            Manage Templates
+          </Link>
+          {exitId && (
+            <button
+              onClick={() => setShowGenerate(!showGenerate)}
+              className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700"
+            >
+              <Plus className="h-4 w-4" />
+              Generate Letter
+            </button>
+          )}
+        </div>
       </div>
 
       {!exitId && (
@@ -153,6 +166,15 @@ export function GeneratedLettersPage() {
                   </option>
                 ))}
               </select>
+              {templates.length === 0 && (
+                <p className="mt-2 text-xs text-gray-500">
+                  No templates configured.{" "}
+                  <Link to="/letters/templates" className="font-medium text-rose-600 hover:underline">
+                    Create a template
+                  </Link>{" "}
+                  to start generating letters.
+                </p>
+              )}
             </div>
           </div>
           <div className="flex gap-3">


### PR DESCRIPTION
## Summary
The **Generate Letter** form had a "Select a template..." dropdown that was always empty for fresh tenants, with no link from anywhere in the app to `/letters/templates`, even though the `LetterTemplatesPage` component and route already exist. Users couldn't find the create-template flow.

## Fix
- Add a **Manage Templates** button (gear icon) in the page header next to "Generate Letter"; routes to `/letters/templates`.
- Add an inline "Create a template" link under the dropdown when no templates exist, so the empty state is self-explanatory.

No backend or routing changes — wiring up an existing route the UI didn't expose.

## Files
- `packages/client/src/pages/letters/GeneratedLettersPage.tsx` (+31 / -9)

## Test plan
- [ ] Visit `/letters?exitId=...` -> "Manage Templates" button visible in header (always, even without exitId)
- [ ] Click it -> lands on `/letters/templates`
- [ ] With zero templates -> open Generate Letter form -> dropdown shows hint with link to create one
- [ ] After creating a template at `/letters/templates`, return to `/letters?exitId=...` -> dropdown is populated
