### PR TITLE
fix(exits): replace native confirm() + silent errors with styled dialog & toasts

### DIFF
--- a/packages/client/src/components/ConfirmDialog.tsx
+++ b/packages/client/src/components/ConfirmDialog.tsx
@@ -1,0 +1,152 @@
+// ============================================================================
+// ConfirmDialog — drop-in replacement for window.confirm()
+//
+// Usage:
+//   <ConfirmDialog
+//     open={isOpen}
+//     title="Mark exit complete?"
+//     description="This will deactivate the employee account."
+//     confirmText="Complete Exit"
+//     variant="danger" | "success" | "info"
+//     loading={mutation.isPending}
+//     onConfirm={() => mutation.mutate()}
+//     onCancel={() => setOpen(false)}
+//   />
+//
+// Plain Tailwind + a portal — no extra dependencies. Closes on ESC or
+// backdrop click (when not loading). Focus is sent to the confirm button
+// on open.
+// ============================================================================
+
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { AlertTriangle, CheckCircle2, Info, X } from "lucide-react";
+
+type Variant = "danger" | "success" | "info";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: Variant;
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const VARIANT_STYLES: Record<Variant, { icon: typeof AlertTriangle; iconBg: string; iconColor: string; button: string }> = {
+  danger: {
+    icon: AlertTriangle,
+    iconBg: "bg-red-50",
+    iconColor: "text-red-600",
+    button: "bg-red-600 hover:bg-red-700",
+  },
+  success: {
+    icon: CheckCircle2,
+    iconBg: "bg-green-50",
+    iconColor: "text-green-600",
+    button: "bg-green-600 hover:bg-green-700",
+  },
+  info: {
+    icon: Info,
+    iconBg: "bg-blue-50",
+    iconColor: "text-blue-600",
+    button: "bg-rose-600 hover:bg-rose-700",
+  },
+};
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  variant = "info",
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
+  const style = VARIANT_STYLES[variant];
+  const Icon = style.icon;
+
+  // ESC closes (unless loading); focus the confirm button on open.
+  useEffect(() => {
+    if (!open) return;
+    confirmBtnRef.current?.focus();
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && !loading) onCancel();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, loading, onCancel]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40 transition-opacity animate-in fade-in"
+        onClick={() => !loading && onCancel()}
+      />
+
+      {/* Card */}
+      <div className="relative w-full max-w-md overflow-hidden rounded-xl bg-white shadow-xl animate-in fade-in zoom-in-95">
+        <button
+          type="button"
+          onClick={() => !loading && onCancel()}
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+          disabled={loading}
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="p-6">
+          <div className="flex items-start gap-4">
+            <div className={`shrink-0 rounded-full p-2 ${style.iconBg}`}>
+              <Icon className={`h-5 w-5 ${style.iconColor}`} />
+            </div>
+            <div className="flex-1">
+              <h2 id="confirm-dialog-title" className="text-base font-semibold text-gray-900">
+                {title}
+              </h2>
+              {description && (
+                <p className="mt-2 text-sm text-gray-600">{description}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {cancelText}
+          </button>
+          <button
+            ref={confirmBtnRef}
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className={`rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${style.button}`}
+          >
+            {loading ? "Working..." : confirmText}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -19,6 +19,8 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 import { apiGet, apiPost, apiPatch } from "@/api/client";
 import { cn, formatDate } from "@/lib/utils";
+import toast from "react-hot-toast";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 const STATUS_COLORS: Record<string, string> = {
   initiated: "bg-blue-100 text-blue-700 border-blue-200",
@@ -87,6 +89,18 @@ export function ExitDetailPage() {
   const [buyout, setBuyout] = useState<any>(null);
   const [actionLoading, setActionLoading] = useState(false);
 
+  // ConfirmDialog driver — single dialog instance multiplexed across the
+  // three confirm() calls this page used to make (cancel exit, complete
+  // exit, approve buyout). `pending` is null when closed; otherwise it
+  // carries the action name so the dialog can render the right copy and
+  // route the confirm callback.
+  const [pendingConfirm, setPendingConfirm] = useState<
+    | { kind: "cancel-exit" }
+    | { kind: "complete-exit" }
+    | { kind: "approve-buyout" }
+    | null
+  >(null);
+
   useEffect(() => {
     loadExit();
   }, [id]);
@@ -138,28 +152,30 @@ export function ExitDetailPage() {
   }
 
   async function handleCancel() {
-    if (!confirm("Are you sure you want to cancel this exit request?")) return;
     setActionLoading(true);
     try {
       await apiPost(`/exits/${id}/cancel`);
+      toast.success("Exit cancelled");
       await loadExit();
-    } catch {
-      // handled
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to cancel exit");
     } finally {
       setActionLoading(false);
+      setPendingConfirm(null);
     }
   }
 
   async function handleComplete() {
-    if (!confirm("Mark this exit as completed? This will deactivate the employee account.")) return;
     setActionLoading(true);
     try {
       await apiPost(`/exits/${id}/complete`);
+      toast.success("Exit marked complete");
       await loadExit();
-    } catch {
-      // handled
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to complete exit");
     } finally {
       setActionLoading(false);
+      setPendingConfirm(null);
     }
   }
 
@@ -231,7 +247,7 @@ export function ExitDetailPage() {
         {!isTerminal && (
           <div className="flex items-center gap-2">
             <button
-              onClick={handleCancel}
+              onClick={() => setPendingConfirm({ kind: "cancel-exit" })}
               disabled={actionLoading}
               className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
             >
@@ -239,7 +255,7 @@ export function ExitDetailPage() {
               Cancel Exit
             </button>
             <button
-              onClick={handleComplete}
+              onClick={() => setPendingConfirm({ kind: "complete-exit" })}
               disabled={actionLoading}
               className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-3 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
             >
@@ -249,6 +265,28 @@ export function ExitDetailPage() {
           </div>
         )}
       </div>
+
+      {/* Confirmation dialogs replacing the native window.confirm() calls. */}
+      <ConfirmDialog
+        open={pendingConfirm?.kind === "cancel-exit"}
+        title="Cancel this exit?"
+        description="The exit request will be cancelled. The employee account will not be deactivated."
+        confirmText="Cancel Exit"
+        variant="danger"
+        loading={actionLoading}
+        onConfirm={handleCancel}
+        onCancel={() => setPendingConfirm(null)}
+      />
+      <ConfirmDialog
+        open={pendingConfirm?.kind === "complete-exit"}
+        title="Mark this exit as completed?"
+        description="This will deactivate the employee account. This action cannot be easily undone."
+        confirmText="Complete Exit"
+        variant="success"
+        loading={actionLoading}
+        onConfirm={handleComplete}
+        onCancel={() => setPendingConfirm(null)}
+      />
 
       {/* Tabs */}
       <div className="border-b border-gray-200">
@@ -542,18 +580,20 @@ function BuyoutTab({
   const [actionLoading, setActionLoading] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
   const [showReject, setShowReject] = useState(false);
+  const [showApproveConfirm, setShowApproveConfirm] = useState(false);
 
   async function handleApprove() {
     if (!buyout) return;
-    if (!confirm("Approve this buyout? The employee's last working date will be updated.")) return;
     setActionLoading(true);
     try {
       await apiPost(`/buyout/${buyout.id}/approve`);
+      toast.success("Buyout approved");
       onReload();
-    } catch {
-      // handled
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to approve buyout");
     } finally {
       setActionLoading(false);
+      setShowApproveConfirm(false);
     }
   }
 
@@ -562,11 +602,12 @@ function BuyoutTab({
     setActionLoading(true);
     try {
       await apiPost(`/buyout/${buyout.id}/reject`, { reason: rejectReason });
+      toast.success("Buyout rejected");
       setShowReject(false);
       setRejectReason("");
       onReload();
-    } catch {
-      // handled
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to reject buyout");
     } finally {
       setActionLoading(false);
     }
@@ -652,13 +693,23 @@ function BuyoutTab({
       {buyout.status === "pending" && (
         <div className="flex items-center gap-3 pt-2">
           <button
-            onClick={handleApprove}
+            onClick={() => setShowApproveConfirm(true)}
             disabled={actionLoading}
             className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
           >
             {actionLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4" />}
             Approve Buyout
           </button>
+          <ConfirmDialog
+            open={showApproveConfirm}
+            title="Approve this buyout?"
+            description="The employee's last working date will be updated and the buyout amount applied to F&F."
+            confirmText="Approve Buyout"
+            variant="success"
+            loading={actionLoading}
+            onConfirm={handleApprove}
+            onCancel={() => setShowApproveConfirm(false)}
+          />
           {!showReject ? (
             <button
               onClick={() => setShowReject(true)}


### PR DESCRIPTION
## Summary
The Exit Detail page used `window.confirm()` for **Cancel Exit**, **Complete Exit**, and **Approve Buyout**, and the catch blocks were `catch { /* handled */ }` — so the user got the bare browser popup, no positive feedback, and complete silence on failure.

## Fix
- New **`<ConfirmDialog />`** component — plain Tailwind + React portal, no new deps. Variants for `danger` / `success` / `info`. ESC + backdrop close, focus-managed, loading state.
- Replace the three `window.confirm()` calls with it.
- Replace the silent `catch {}` blocks with proper toast feedback using the existing `react-hot-toast` Toaster:
  - **success**: "Exit cancelled" / "Exit marked complete" / "Buyout approved" / "Buyout rejected"
  - **error**: surface `err.response.data.error.message`, falling back to a generic line.
- Buyout reject also gets the same toast pair (was the same silent-error pattern).

## Files
- `packages/client/src/components/ConfirmDialog.tsx` (new, +152)
- `packages/client/src/pages/exits/ExitDetailPage.tsx` (+65 / -14)

## Test plan
- [ ] Click **Cancel Exit** -> styled red dialog ("Cancel this exit?") opens. Confirm -> success toast + status flips. Backend 400 -> error toast surfaces server message.
- [ ] Click **Complete Exit** -> styled green dialog ("Mark this exit as completed?") opens. Confirm -> success toast + employee account deactivates.
- [ ] Click **Approve Buyout** (in the Buyout tab) -> green dialog. Confirm -> success toast + buyout status flips.
- [ ] Reject buyout -> success/error toast as appropriate.
- [ ] ESC closes the dialog; backdrop click closes it; both blocked while loading.

The component is reusable for the other `confirm()` calls in this app (KT, FnF, Assets, etc.) if we want to sweep them in a follow-up.
