### PR TITLE
fix: interview templates delete button + stop rendering 0 badges

### DIFF
--- a/packages/client/src/pages/interviews/InterviewTemplatesPage.tsx
+++ b/packages/client/src/pages/interviews/InterviewTemplatesPage.tsx
@@ -196,6 +196,25 @@ export function InterviewTemplatesPage() {
     }
   };
 
+  const handleDeleteTemplate = async (templateId: string, templateName: string) => {
+    if (!confirm(`Delete template "${templateName}" and all its questions? This cannot be undone.`)) {
+      return;
+    }
+    try {
+      await apiDelete(`/interviews/templates/${templateId}`);
+      if (expandedId === templateId) {
+        setExpandedId(null);
+        setExpandedTemplate(null);
+      }
+      if (editingTemplate === templateId) {
+        setEditingTemplate(null);
+      }
+      await fetchTemplates();
+    } catch {
+      setError("Failed to delete template");
+    }
+  };
+
   const handleDragEnd = async () => {
     if (
       dragIndex === null ||
@@ -365,7 +384,7 @@ export function InterviewTemplatesPage() {
                   <div>
                     <div className="flex items-center gap-2">
                       <span className="font-medium text-gray-900">{t.name}</span>
-                      {t.is_default && (
+                      {Boolean(t.is_default) && (
                         <span className="inline-flex items-center rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-700">
                           Default
                         </span>
@@ -381,15 +400,28 @@ export function InterviewTemplatesPage() {
                     )}
                   </div>
                 </div>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    startEditTemplate(t);
-                  }}
-                  className="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                >
-                  <Pencil className="h-4 w-4" />
-                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      startEditTemplate(t);
+                    }}
+                    className="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                    title="Edit template"
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteTemplate(t.id, t.name);
+                    }}
+                    className="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                    title="Delete template"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
               </div>
 
               {/* Expanded: Questions */}
@@ -446,7 +478,7 @@ export function InterviewTemplatesPage() {
                               {QUESTION_TYPES.find((qt) => qt.value === q.question_type)?.icon}
                               {QUESTION_TYPES.find((qt) => qt.value === q.question_type)?.label}
                             </span>
-                            {q.is_required && (
+                            {Boolean(q.is_required) && (
                               <span className="text-xs text-red-500">Required</span>
                             )}
                           </div>

--- a/packages/server/src/api/routes/interview.routes.ts
+++ b/packages/server/src/api/routes/interview.routes.ts
@@ -90,6 +90,21 @@ router.put(
   },
 );
 
+// DELETE /templates/:id — delete template (questions cascade in DB)
+router.delete(
+  "/templates/:id",
+  authorize("org_admin", "hr_admin", "hr_manager"),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      await interviewService.deleteTemplate(orgId, req.params.id as string);
+      sendSuccess(res, { message: "Template deleted" });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // POST /templates/:id/questions — add a question to template
 router.post(
   "/templates/:id/questions",

--- a/packages/server/src/services/interview/exit-interview.service.ts
+++ b/packages/server/src/services/interview/exit-interview.service.ts
@@ -95,6 +95,18 @@ export async function updateTemplate(
   return updated;
 }
 
+// Delete a template (and its questions, via FK cascade).
+export async function deleteTemplate(orgId: number, templateId: string): Promise<void> {
+  const db = getDB();
+  const existing = await db.findOne<ExitInterviewTemplate>("exit_interview_templates", {
+    id: templateId,
+    organization_id: orgId,
+  });
+  if (!existing) throw new NotFoundError("Interview template", templateId);
+  await db.delete("exit_interview_templates", templateId);
+  logger.info(`Interview template deleted: ${templateId}`);
+}
+
 // ---------------------------------------------------------------------------
 // Question management
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a delete button (trash icon) to each interview template row, wired to a new DELETE /interviews/templates/:id endpoint plus deleteTemplate service. Confirms before deleting and cleans up expanded/editing state (#15).
- MySQL tinyint values (0/1) for is_default and is_required were being rendered as the literal "0" next to the template name and question rows because of {flag && ...}. Wrap with Boolean(...) so 0 short-circuits to false instead of bleeding into the DOM (#16).

Closes #15
Closes #16

## Test plan
- [ ] On Interview Templates, each row shows both edit and delete icons.
- [ ] Click delete -> confirm prompt -> template removed.
- [ ] Open a template that is not default; no stray "0" appears next to the template name or question rows.