### PR TITLE
feat(exit): implement Knowledge Transfer (KT) tab

### DIFF
--- a/packages/client/src/components/ConfirmDialog.tsx
+++ b/packages/client/src/components/ConfirmDialog.tsx
@@ -1,152 +1,87 @@
-// ============================================================================
-// ConfirmDialog — drop-in replacement for window.confirm()
-//
-// Usage:
-//   <ConfirmDialog
-//     open={isOpen}
-//     title="Mark exit complete?"
-//     description="This will deactivate the employee account."
-//     confirmText="Complete Exit"
-//     variant="danger" | "success" | "info"
-//     loading={mutation.isPending}
-//     onConfirm={() => mutation.mutate()}
-//     onCancel={() => setOpen(false)}
-//   />
-//
-// Plain Tailwind + a portal — no extra dependencies. Closes on ESC or
-// backdrop click (when not loading). Focus is sent to the confirm button
-// on open.
-// ============================================================================
-
-import { useEffect, useRef } from "react";
-import { createPortal } from "react-dom";
-import { AlertTriangle, CheckCircle2, Info, X } from "lucide-react";
-
-type Variant = "danger" | "success" | "info";
+import { AlertTriangle, Loader2 } from "lucide-react";
 
 interface ConfirmDialogProps {
   open: boolean;
   title: string;
-  description?: string;
-  confirmText?: string;
-  cancelText?: string;
-  variant?: Variant;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** "danger" = red confirm button, "primary" = brand-coloured confirm button */
+  tone?: "danger" | "primary";
   loading?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
-const VARIANT_STYLES: Record<Variant, { icon: typeof AlertTriangle; iconBg: string; iconColor: string; button: string }> = {
-  danger: {
-    icon: AlertTriangle,
-    iconBg: "bg-red-50",
-    iconColor: "text-red-600",
-    button: "bg-red-600 hover:bg-red-700",
-  },
-  success: {
-    icon: CheckCircle2,
-    iconBg: "bg-green-50",
-    iconColor: "text-green-600",
-    button: "bg-green-600 hover:bg-green-700",
-  },
-  info: {
-    icon: Info,
-    iconBg: "bg-blue-50",
-    iconColor: "text-blue-600",
-    button: "bg-rose-600 hover:bg-rose-700",
-  },
-};
-
+/**
+ * Reusable in-app confirmation dialog — replaces native window.confirm() so
+ * destructive/irreversible actions get a styled, on-brand prompt instead of the
+ * browser's "<host> says…" alert.
+ */
 export function ConfirmDialog({
   open,
   title,
-  description,
-  confirmText = "Confirm",
-  cancelText = "Cancel",
-  variant = "info",
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  tone = "primary",
   loading = false,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
-  const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
-  const style = VARIANT_STYLES[variant];
-  const Icon = style.icon;
-
-  // ESC closes (unless loading); focus the confirm button on open.
-  useEffect(() => {
-    if (!open) return;
-    confirmBtnRef.current?.focus();
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && !loading) onCancel();
-    }
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [open, loading, onCancel]);
-
   if (!open) return null;
 
-  return createPortal(
+  const confirmClasses =
+    tone === "danger"
+      ? "bg-red-600 hover:bg-red-700"
+      : "bg-rose-600 hover:bg-rose-700";
+
+  return (
     <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="confirm-dialog-title"
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={loading ? undefined : onCancel}
     >
-      {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/40 transition-opacity animate-in fade-in"
-        onClick={() => !loading && onCancel()}
-      />
-
-      {/* Card */}
-      <div className="relative w-full max-w-md overflow-hidden rounded-xl bg-white shadow-xl animate-in fade-in zoom-in-95">
-        <button
-          type="button"
-          onClick={() => !loading && onCancel()}
-          aria-label="Close"
-          className="absolute right-3 top-3 rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
-          disabled={loading}
-        >
-          <X className="h-4 w-4" />
-        </button>
-
-        <div className="p-6">
-          <div className="flex items-start gap-4">
-            <div className={`shrink-0 rounded-full p-2 ${style.iconBg}`}>
-              <Icon className={`h-5 w-5 ${style.iconColor}`} />
-            </div>
-            <div className="flex-1">
-              <h2 id="confirm-dialog-title" className="text-base font-semibold text-gray-900">
-                {title}
-              </h2>
-              {description && (
-                <p className="mt-2 text-sm text-gray-600">{description}</p>
-              )}
-            </div>
+        className="w-full max-w-md rounded-xl bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className="flex items-start gap-3 px-5 pt-5">
+          <div
+            className={
+              "flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full " +
+              (tone === "danger" ? "bg-red-50 text-red-600" : "bg-rose-50 text-rose-600")
+            }
+          >
+            <AlertTriangle className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-gray-900">{title}</h3>
+            <p className="mt-1 text-sm text-gray-600">{message}</p>
           </div>
         </div>
-
-        <div className="flex justify-end gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4">
+        <div className="mt-5 flex justify-end gap-2 border-t border-gray-200 px-5 py-4">
           <button
-            type="button"
             onClick={onCancel}
             disabled={loading}
-            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
           >
-            {cancelText}
+            {cancelLabel}
           </button>
           <button
-            ref={confirmBtnRef}
-            type="button"
             onClick={onConfirm}
             disabled={loading}
-            className={`rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${style.button}`}
+            className={
+              "inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 " +
+              confirmClasses
+            }
           >
-            {loading ? "Working..." : confirmText}
+            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+            {confirmLabel}
           </button>
         </div>
       </div>
-    </div>,
-    document.body,
+    </div>
   );
 }

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -15,12 +15,13 @@ import {
   FileSignature,
   ArrowLeft,
   Clock,
+  Pencil,
 } from "lucide-react";
 import { Link as RouterLink } from "react-router-dom";
-import { apiGet, apiPost, apiPatch } from "@/api/client";
-import { cn, formatDate } from "@/lib/utils";
 import toast from "react-hot-toast";
+import { apiGet, apiPost, apiPatch, apiPut } from "@/api/client";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { cn, formatDate } from "@/lib/utils";
 
 const STATUS_COLORS: Record<string, string> = {
   initiated: "bg-blue-100 text-blue-700 border-blue-200",
@@ -49,6 +50,21 @@ const TYPE_LABELS: Record<string, string> = {
   end_of_contract: "End of Contract",
   mutual_separation: "Mutual Separation",
 };
+
+// Reason categories accepted by updateExitSchema (shared validators).
+const REASON_OPTIONS: { value: string; label: string }[] = [
+  { value: "better_opportunity", label: "Better Opportunity" },
+  { value: "compensation", label: "Compensation" },
+  { value: "relocation", label: "Relocation" },
+  { value: "personal", label: "Personal" },
+  { value: "health", label: "Health" },
+  { value: "higher_education", label: "Higher Education" },
+  { value: "retirement", label: "Retirement" },
+  { value: "performance", label: "Performance" },
+  { value: "misconduct", label: "Misconduct" },
+  { value: "redundancy", label: "Redundancy" },
+  { value: "other", label: "Other" },
+];
 
 const CHECKLIST_STATUS_COLORS: Record<string, string> = {
   pending: "bg-gray-100 text-gray-600",
@@ -88,18 +104,18 @@ export function ExitDetailPage() {
   const [clearance, setClearance] = useState<any>(null);
   const [buyout, setBuyout] = useState<any>(null);
   const [actionLoading, setActionLoading] = useState(false);
-
-  // ConfirmDialog driver — single dialog instance multiplexed across the
-  // three confirm() calls this page used to make (cancel exit, complete
-  // exit, approve buyout). `pending` is null when closed; otherwise it
-  // carries the action name so the dialog can render the right copy and
-  // route the confirm callback.
-  const [pendingConfirm, setPendingConfirm] = useState<
-    | { kind: "cancel-exit" }
-    | { kind: "complete-exit" }
-    | { kind: "approve-buyout" }
-    | null
-  >(null);
+  const [showEdit, setShowEdit] = useState(false);
+  const [editForm, setEditForm] = useState<any>({});
+  const [editError, setEditError] = useState<string | null>(null);
+  // Generic in-app confirmation dialog (replaces native confirm()).
+  const [confirmState, setConfirmState] = useState<{
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel: string;
+    tone: "danger" | "primary";
+    onConfirm: () => void;
+  } | null>(null);
 
   useEffect(() => {
     loadExit();
@@ -151,31 +167,107 @@ export function ExitDetailPage() {
     }
   }
 
-  async function handleCancel() {
+  function openEdit() {
+    setEditForm({
+      reason_category: exit.reason_category ?? "",
+      reason_detail: exit.reason_detail ?? "",
+      notice_start_date: exit.notice_start_date ? String(exit.notice_start_date).slice(0, 10) : "",
+      last_working_date: exit.last_working_date ? String(exit.last_working_date).slice(0, 10) : "",
+      actual_exit_date: exit.actual_exit_date ? String(exit.actual_exit_date).slice(0, 10) : "",
+      notice_period_days: exit.notice_period_days ?? 30,
+      notice_period_waived: !!exit.notice_period_waived,
+    });
+    setEditError(null);
+    setShowEdit(true);
+  }
+
+  async function handleSaveEdit() {
     setActionLoading(true);
+    setEditError(null);
+    // Send only fields with a value; the API schema accepts all of these optionally.
+    const payload: Record<string, any> = {
+      reason_category: editForm.reason_category || undefined,
+      reason_detail: editForm.reason_detail || undefined,
+      notice_start_date: editForm.notice_start_date || undefined,
+      last_working_date: editForm.last_working_date || undefined,
+      actual_exit_date: editForm.actual_exit_date || undefined,
+      notice_period_days:
+        editForm.notice_period_days === "" || editForm.notice_period_days == null
+          ? undefined
+          : Number(editForm.notice_period_days),
+      notice_period_waived: !!editForm.notice_period_waived,
+    };
     try {
-      await apiPost(`/exits/${id}/cancel`);
-      toast.success("Exit cancelled");
+      await apiPut(`/exits/${id}`, payload);
+      setShowEdit(false);
       await loadExit();
+      toast.success("Exit details updated successfully");
     } catch (err: any) {
-      toast.error(err?.response?.data?.error?.message || "Failed to cancel exit");
+      const msg =
+        err?.response?.data?.error?.message ||
+        err?.response?.data?.error ||
+        err?.message ||
+        "Failed to update exit details";
+      setEditError(msg);
+      toast.error(msg);
     } finally {
       setActionLoading(false);
-      setPendingConfirm(null);
     }
   }
 
-  async function handleComplete() {
+  function handleCancel() {
+    setConfirmState({
+      open: true,
+      title: "Cancel exit request?",
+      message: "This will mark the exit request as cancelled. This action cannot be undone.",
+      confirmLabel: "Cancel Exit",
+      tone: "danger",
+      onConfirm: doCancel,
+    });
+  }
+
+  async function doCancel() {
+    setActionLoading(true);
+    try {
+      await apiPost(`/exits/${id}/cancel`);
+      await loadExit();
+      setConfirmState(null);
+      toast.success("Exit request cancelled");
+    } catch (err: any) {
+      setConfirmState(null);
+      toast.error(
+        err?.response?.data?.error?.message || err?.message || "Failed to cancel exit request",
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  function handleComplete() {
+    setConfirmState({
+      open: true,
+      title: "Mark exit as completed?",
+      message: "This will finalize the exit and deactivate the employee's account. This action cannot be undone.",
+      confirmLabel: "Complete Exit",
+      tone: "primary",
+      onConfirm: doComplete,
+    });
+  }
+
+  async function doComplete() {
     setActionLoading(true);
     try {
       await apiPost(`/exits/${id}/complete`);
-      toast.success("Exit marked complete");
       await loadExit();
+      setConfirmState(null);
+      toast.success("Exit marked as completed");
     } catch (err: any) {
-      toast.error(err?.response?.data?.error?.message || "Failed to complete exit");
+      setConfirmState(null);
+      toast.error(
+        err?.response?.data?.error?.message || err?.message || "Failed to complete exit",
+      );
     } finally {
       setActionLoading(false);
-      setPendingConfirm(null);
     }
   }
 
@@ -247,7 +339,15 @@ export function ExitDetailPage() {
         {!isTerminal && (
           <div className="flex items-center gap-2">
             <button
-              onClick={() => setPendingConfirm({ kind: "cancel-exit" })}
+              onClick={openEdit}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              <Pencil className="h-4 w-4" />
+              Edit
+            </button>
+            <button
+              onClick={handleCancel}
               disabled={actionLoading}
               className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
             >
@@ -255,7 +355,7 @@ export function ExitDetailPage() {
               Cancel Exit
             </button>
             <button
-              onClick={() => setPendingConfirm({ kind: "complete-exit" })}
+              onClick={handleComplete}
               disabled={actionLoading}
               className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-3 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
             >
@@ -265,28 +365,6 @@ export function ExitDetailPage() {
           </div>
         )}
       </div>
-
-      {/* Confirmation dialogs replacing the native window.confirm() calls. */}
-      <ConfirmDialog
-        open={pendingConfirm?.kind === "cancel-exit"}
-        title="Cancel this exit?"
-        description="The exit request will be cancelled. The employee account will not be deactivated."
-        confirmText="Cancel Exit"
-        variant="danger"
-        loading={actionLoading}
-        onConfirm={handleCancel}
-        onCancel={() => setPendingConfirm(null)}
-      />
-      <ConfirmDialog
-        open={pendingConfirm?.kind === "complete-exit"}
-        title="Mark this exit as completed?"
-        description="This will deactivate the employee account. This action cannot be easily undone."
-        confirmText="Complete Exit"
-        variant="success"
-        loading={actionLoading}
-        onConfirm={handleComplete}
-        onCancel={() => setPendingConfirm(null)}
-      />
 
       {/* Tabs */}
       <div className="border-b border-gray-200">
@@ -333,6 +411,98 @@ export function ExitDetailPage() {
         {activeTab === "kt" && <PlaceholderTab name="Knowledge Transfer" />}
         {activeTab === "letters" && <PlaceholderTab name="Exit Letters" />}
       </div>
+
+      {/* Edit Exit modal */}
+      {showEdit && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-lg rounded-xl bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+              <h3 className="text-lg font-semibold text-gray-900">Edit Exit Details</h3>
+              <button onClick={() => setShowEdit(false)} className="text-gray-400 hover:text-gray-600">
+                <XCircle className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="max-h-[70vh] space-y-4 overflow-y-auto px-5 py-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">Reason Category</label>
+                <select
+                  value={editForm.reason_category}
+                  onChange={(e) => setEditForm({ ...editForm, reason_category: e.target.value })}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+                >
+                  {REASON_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>{o.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">Reason Detail</label>
+                <textarea
+                  value={editForm.reason_detail}
+                  onChange={(e) => setEditForm({ ...editForm, reason_detail: e.target.value })}
+                  rows={3}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">Notice Start</label>
+                  <input type="date" value={editForm.notice_start_date}
+                    onChange={(e) => setEditForm({ ...editForm, notice_start_date: e.target.value })}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none" />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">Last Working Date</label>
+                  <input type="date" value={editForm.last_working_date}
+                    onChange={(e) => setEditForm({ ...editForm, last_working_date: e.target.value })}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none" />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">Actual Exit Date</label>
+                  <input type="date" value={editForm.actual_exit_date}
+                    onChange={(e) => setEditForm({ ...editForm, actual_exit_date: e.target.value })}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none" />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">Notice Period (days)</label>
+                  <input type="number" min={0} value={editForm.notice_period_days}
+                    onChange={(e) => setEditForm({ ...editForm, notice_period_days: e.target.value })}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none" />
+                </div>
+              </div>
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input type="checkbox" checked={!!editForm.notice_period_waived}
+                  onChange={(e) => setEditForm({ ...editForm, notice_period_waived: e.target.checked })} />
+                Notice period waived
+              </label>
+              {editError && <p className="text-sm text-red-600">{editError}</p>}
+            </div>
+            <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-4">
+              <button onClick={() => setShowEdit(false)} disabled={actionLoading}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                Cancel
+              </button>
+              <button onClick={handleSaveEdit} disabled={actionLoading}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50">
+                {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+                Save Changes
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* In-app confirmation dialog (replaces native confirm()) */}
+      <ConfirmDialog
+        open={!!confirmState?.open}
+        title={confirmState?.title ?? ""}
+        message={confirmState?.message ?? ""}
+        confirmLabel={confirmState?.confirmLabel ?? "Confirm"}
+        tone={confirmState?.tone ?? "primary"}
+        loading={actionLoading}
+        onConfirm={() => confirmState?.onConfirm()}
+        onCancel={() => setConfirmState(null)}
+      />
     </div>
   );
 }
@@ -580,20 +750,18 @@ function BuyoutTab({
   const [actionLoading, setActionLoading] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
   const [showReject, setShowReject] = useState(false);
-  const [showApproveConfirm, setShowApproveConfirm] = useState(false);
 
   async function handleApprove() {
     if (!buyout) return;
+    if (!confirm("Approve this buyout? The employee's last working date will be updated.")) return;
     setActionLoading(true);
     try {
       await apiPost(`/buyout/${buyout.id}/approve`);
-      toast.success("Buyout approved");
       onReload();
-    } catch (err: any) {
-      toast.error(err?.response?.data?.error?.message || "Failed to approve buyout");
+    } catch {
+      // handled
     } finally {
       setActionLoading(false);
-      setShowApproveConfirm(false);
     }
   }
 
@@ -602,12 +770,11 @@ function BuyoutTab({
     setActionLoading(true);
     try {
       await apiPost(`/buyout/${buyout.id}/reject`, { reason: rejectReason });
-      toast.success("Buyout rejected");
       setShowReject(false);
       setRejectReason("");
       onReload();
-    } catch (err: any) {
-      toast.error(err?.response?.data?.error?.message || "Failed to reject buyout");
+    } catch {
+      // handled
     } finally {
       setActionLoading(false);
     }
@@ -693,23 +860,13 @@ function BuyoutTab({
       {buyout.status === "pending" && (
         <div className="flex items-center gap-3 pt-2">
           <button
-            onClick={() => setShowApproveConfirm(true)}
+            onClick={handleApprove}
             disabled={actionLoading}
             className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
           >
             {actionLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4" />}
             Approve Buyout
           </button>
-          <ConfirmDialog
-            open={showApproveConfirm}
-            title="Approve this buyout?"
-            description="The employee's last working date will be updated and the buyout amount applied to F&F."
-            confirmText="Approve Buyout"
-            variant="success"
-            loading={actionLoading}
-            onConfirm={handleApprove}
-            onCancel={() => setShowApproveConfirm(false)}
-          />
           {!showReject ? (
             <button
               onClick={() => setShowReject(true)}

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -103,6 +103,7 @@ export function ExitDetailPage() {
   const [checklist, setChecklist] = useState<any>(null);
   const [clearance, setClearance] = useState<any>(null);
   const [buyout, setBuyout] = useState<any>(null);
+  const [kt, setKt] = useState<any>(null);
   const [actionLoading, setActionLoading] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
   const [editForm, setEditForm] = useState<any>({});
@@ -126,6 +127,7 @@ export function ExitDetailPage() {
     if (activeTab === "checklist") loadChecklist();
     if (activeTab === "clearance") loadClearance();
     if (activeTab === "buyout") loadBuyout();
+    if (activeTab === "kt") loadKt();
   }, [activeTab, id, exit]);
 
   async function loadExit() {
@@ -292,6 +294,25 @@ export function ExitDetailPage() {
     }
   }
 
+  async function loadKt() {
+    try {
+      const res = await apiGet<any>(`/kt/exit/${id}`);
+      setKt(res.data);
+    } catch {
+      setKt(null);
+    }
+  }
+
+  async function handleKtItemUpdate(itemId: string, status: string) {
+    try {
+      await apiPut(`/kt/items/${itemId}`, { status });
+      await loadKt();
+      toast.success("Knowledge transfer item updated");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to update KT item");
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -408,7 +429,7 @@ export function ExitDetailPage() {
         {activeTab === "fnf" && <PlaceholderTab name="Full & Final Settlement" />}
         {activeTab === "buyout" && <BuyoutTab buyout={buyout} exitId={id!} onReload={loadBuyout} />}
         {activeTab === "assets" && <PlaceholderTab name="Asset Returns" />}
-        {activeTab === "kt" && <PlaceholderTab name="Knowledge Transfer" />}
+        {activeTab === "kt" && <KtTab kt={kt} onUpdateItem={handleKtItemUpdate} />}
         {activeTab === "letters" && <PlaceholderTab name="Exit Letters" />}
       </div>
 
@@ -648,6 +669,128 @@ function ChecklistTab({
           </div>
         ))}
       </div>
+    </div>
+  );
+}
+
+const KT_STATUS_COLORS: Record<string, string> = {
+  not_started: "bg-gray-100 text-gray-600",
+  in_progress: "bg-blue-100 text-blue-700",
+  completed: "bg-green-100 text-green-700",
+};
+
+function KtTab({
+  kt,
+  onUpdateItem,
+}: {
+  kt: any;
+  onUpdateItem: (itemId: string, status: string) => void;
+}) {
+  if (!kt) {
+    return (
+      <div className="py-8 text-center">
+        <BookOpen className="mx-auto mb-3 h-10 w-10 text-gray-300" />
+        <p className="mb-1 text-sm text-gray-500">No knowledge transfer plan yet.</p>
+        <p className="text-xs text-gray-400">
+          A KT plan is created when handover tasks are assigned for this exit.
+        </p>
+      </div>
+    );
+  }
+
+  const items: any[] = Array.isArray(kt.items) ? kt.items : [];
+  const completed = items.filter((i) => i.status === "completed").length;
+  const total = items.length;
+  const progress = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  return (
+    <div className="space-y-5">
+      {/* Plan summary */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
+          <span
+            className={cn(
+              "inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium",
+              KT_STATUS_COLORS[kt.status] || "bg-gray-100 text-gray-600",
+            )}
+          >
+            {String(kt.status || "not_started").replace(/_/g, " ")}
+          </span>
+          {kt.assignee && (
+            <span>
+              Assignee: <span className="font-medium text-gray-800">{kt.assignee.first_name} {kt.assignee.last_name}</span>
+            </span>
+          )}
+          {kt.due_date && <span>Due: {formatDate(kt.due_date)}</span>}
+        </div>
+        <span className="text-sm font-medium text-gray-700">
+          {completed} / {total} completed ({progress}%)
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-2 w-full rounded-full bg-gray-200">
+        <div className="h-2 rounded-full bg-rose-500 transition-all" style={{ width: `${progress}%` }} />
+      </div>
+
+      {kt.notes && (
+        <p className="rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-600">{kt.notes}</p>
+      )}
+
+      {/* Items */}
+      {total === 0 ? (
+        <p className="py-4 text-center text-sm text-gray-400">No knowledge transfer items added yet.</p>
+      ) : (
+        <div className="divide-y divide-gray-100">
+          {items.map((item) => (
+            <div key={item.id} className="flex items-center justify-between py-3">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-gray-900">{item.title}</p>
+                {item.description && (
+                  <p className="mt-0.5 text-xs text-gray-500">{item.description}</p>
+                )}
+                {item.document_url && (
+                  <a
+                    href={item.document_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-0.5 inline-block text-xs text-rose-600 hover:underline"
+                  >
+                    View document
+                  </a>
+                )}
+              </div>
+              <div className="ml-4 flex items-center gap-2">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full px-2 py-0.5 text-xs font-medium",
+                    KT_STATUS_COLORS[item.status] || "bg-gray-100 text-gray-600",
+                  )}
+                >
+                  {String(item.status).replace(/_/g, " ")}
+                </span>
+                {item.status === "not_started" && (
+                  <button
+                    onClick={() => onUpdateItem(item.id, "in_progress")}
+                    className="rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-100"
+                  >
+                    Start
+                  </button>
+                )}
+                {item.status !== "completed" && (
+                  <button
+                    onClick={() => onUpdateItem(item.id, "completed")}
+                    className="rounded-md bg-green-50 p-1 text-green-600 hover:bg-green-100"
+                    title="Mark complete"
+                  >
+                    <CheckCircle className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/server/src/db/seeds/sql/01_exit_seed.ts
+++ b/packages/server/src/db/seeds/sql/01_exit_seed.ts
@@ -1,0 +1,179 @@
+/**
+ * emp-exit dummy/test seed.
+ *
+ * Inserts realistic exit-management test data for the existing dev tenant so the
+ * UI can be exercised across every status. Wired to the REAL empcloud records
+ * that already exist locally:
+ *   - organization_id = 3  (TechNova Solutions)
+ *   - employees        = users.id 12..21 (Rahul, Priya, Sneha, Arjun, etc.)
+ *
+ * Notes on the data layer (see knex.adapter.ts):
+ *   - This seed runs via `npm run db:seed` (tsx src/db/seed.ts). The `knex` arg
+ *     is bound to the emp_exit DB. We do NOT touch empcloud here — its org/users
+ *     already exist; we only reference their ids.
+ *   - emp_exit PKs are app-generated UUIDs (no DB autoincrement, no default), so
+ *     every row supplies an explicit `id`.
+ *   - created_at/updated_at are omitted (DB CURRENT_TIMESTAMP defaults apply).
+ *   - Monetary amounts are BIGINT in the smallest unit (paise).
+ *   - Idempotent: all org-3 exit data is deleted (reverse-FK order) then
+ *     re-inserted, so re-running is safe.
+ */
+import type { Knex } from "knex";
+import { v4 as uuidv4 } from "uuid";
+
+const ORG_ID = 3;
+
+// Real empcloud users.id values for TechNova (org 3).
+const EMP = {
+  ananya: 12,   // org_admin (acts as initiator/approver)
+  rahul: 13,    // employee
+  priya: 14,    // employee
+  vikram: 15,   // hr_manager
+  sneha: 16,    // employee
+  arjun: 17,    // employee
+  meera: 18,    // hr_manager (interviewer)
+  karthik: 19,  // employee
+  divya: 20,    // employee
+  aditya: 21,   // employee
+};
+
+export async function seed(knex: Knex): Promise<void> {
+  // ── Idempotency: wipe org-3 exit data (RESTRICT/no-FK children first, then
+  //    exit_requests which cascades the rest, then org-config tables). Child
+  //    tables without organization_id are scoped via an exit_requests subquery
+  //    so moving UUIDs don't matter. ─────────────────────────────────────────
+  const exitSub = () => knex("exit_requests").where({ organization_id: ORG_ID }).select("id");
+
+  await knex("rehire_requests").where({ organization_id: ORG_ID }).del().catch(() => {});
+  await knex("notice_buyout_requests").where({ organization_id: ORG_ID }).del().catch(() => {});
+  await knex("generated_letters").whereIn("exit_request_id", exitSub()).del().catch(() => {});
+  await knex("alumni_profiles").where({ organization_id: ORG_ID }).del().catch(() => {});
+  await knex("audit_logs").where({ organization_id: ORG_ID }).del().catch(() => {});
+  await knex("flight_risk_scores").where({ organization_id: ORG_ID }).del().catch(() => {});
+  await knex("attrition_predictions").where({ organization_id: ORG_ID }).del().catch(() => {});
+  await knex("kt_items").whereIn("kt_id", knex("knowledge_transfers").whereIn("exit_request_id", exitSub()).select("id")).del().catch(() => {});
+  // exit_requests delete cascades: checklist_instances, clearance_records,
+  // exit_interviews(+responses), fnf_settlements, asset_returns, knowledge_transfers(+kt_items).
+  await knex("exit_requests").where({ organization_id: ORG_ID }).del();
+  await knex("clearance_departments").where({ organization_id: ORG_ID }).del();
+  await knex("exit_checklist_templates").where({ organization_id: ORG_ID }).del();
+  await knex("exit_interview_templates").where({ organization_id: ORG_ID }).del();
+  await knex("letter_templates").where({ organization_id: ORG_ID }).del();
+  await knex("exit_settings").where({ organization_id: ORG_ID }).del();
+
+  // ── Org-level config ───────────────────────────────────────────────────────
+  await knex("exit_settings").insert({
+    id: uuidv4(),
+    organization_id: ORG_ID,
+    default_notice_period_days: 30,
+    auto_initiate_clearance: 1,
+    require_exit_interview: 1,
+    fnf_approval_required: 1,
+    alumni_opt_in_default: 1,
+    email_on_exit_initiated: 1,
+    email_on_clearance_pending: 1,
+    email_on_clearance_completed: 1,
+    email_on_fnf_calculated: 1,
+    email_on_fnf_approved: 1,
+    email_on_exit_completed: 1,
+  });
+
+  // Clearance departments (capture ids for clearance_records).
+  const clrDept = {
+    it: uuidv4(), finance: uuidv4(), hr: uuidv4(),
+    manager: uuidv4(), library: uuidv4(), security: uuidv4(),
+  };
+  await knex("clearance_departments").insert([
+    { id: clrDept.it, organization_id: ORG_ID, name: "IT / Systems", approver_role: "it_admin", sort_order: 1, is_active: 1 },
+    { id: clrDept.finance, organization_id: ORG_ID, name: "Finance / Accounts", approver_role: "finance", sort_order: 2, is_active: 1 },
+    { id: clrDept.hr, organization_id: ORG_ID, name: "HR / Admin", approver_role: "hr_admin", sort_order: 3, is_active: 1 },
+    { id: clrDept.manager, organization_id: ORG_ID, name: "Reporting Manager", approver_role: "manager", sort_order: 4, is_active: 1 },
+    { id: clrDept.library, organization_id: ORG_ID, name: "Library / Knowledge Base", approver_role: "admin", sort_order: 5, is_active: 1 },
+    { id: clrDept.security, organization_id: ORG_ID, name: "Security / Facilities", approver_role: "admin", sort_order: 6, is_active: 1 },
+  ]);
+
+  // Interview template + questions.
+  const interviewTpl = uuidv4();
+  await knex("exit_interview_templates").insert({
+    id: interviewTpl, organization_id: ORG_ID, name: "Standard Exit Interview", is_default: 1, is_active: 1,
+  });
+  const q = { reason: uuidv4(), experience: uuidv4(), recommend: uuidv4(), mgmt: uuidv4() };
+  await knex("exit_interview_questions").insert([
+    { id: q.reason, template_id: interviewTpl, question_text: "What is the primary reason for leaving?", question_type: "text", sort_order: 1, is_required: 1 },
+    { id: q.experience, template_id: interviewTpl, question_text: "Rate your overall experience", question_type: "rating", sort_order: 2, is_required: 0 },
+    { id: q.recommend, template_id: interviewTpl, question_text: "Would you recommend us as an employer?", question_type: "yes_no", sort_order: 3, is_required: 0 },
+    { id: q.mgmt, template_id: interviewTpl, question_text: "How would you rate management support?", question_type: "rating", sort_order: 4, is_required: 0 },
+  ]);
+
+  // ── Exit requests (root) — one per status to exercise the full lifecycle ────
+  const exit = {
+    priya: uuidv4(), rahul: uuidv4(), divya: uuidv4(),
+    vikram: uuidv4(), sneha: uuidv4(), arjun: uuidv4(), karthik: uuidv4(),
+  };
+  await knex("exit_requests").insert([
+    { id: exit.priya, organization_id: ORG_ID, employee_id: EMP.priya, exit_type: "resignation", status: "clearance_pending", reason_category: "better_opportunity", reason_detail: "Accepted a Senior Engineer offer at a product company.", initiated_by: EMP.ananya, approved_by: EMP.ananya, resignation_date: "2026-05-02", notice_start_date: "2026-05-02", last_working_date: "2026-06-01", notice_period_days: 30, notice_period_waived: 0 },
+    { id: exit.rahul, organization_id: ORG_ID, employee_id: EMP.rahul, exit_type: "resignation", status: "fnf_pending", reason_category: "compensation", reason_detail: "Compensation below market; declined counter-offer.", initiated_by: EMP.ananya, approved_by: EMP.ananya, resignation_date: "2026-04-15", notice_start_date: "2026-04-15", last_working_date: "2026-05-15", notice_period_days: 30, notice_period_waived: 0 },
+    { id: exit.divya, organization_id: ORG_ID, employee_id: EMP.divya, exit_type: "retirement", status: "completed", reason_category: "retirement", reason_detail: "Superannuation at age 60.", initiated_by: EMP.ananya, approved_by: EMP.ananya, resignation_date: "2026-03-01", last_working_date: "2026-03-31", actual_exit_date: "2026-03-31", notice_period_days: 30, notice_period_waived: 0 },
+    { id: exit.vikram, organization_id: ORG_ID, employee_id: EMP.vikram, exit_type: "termination", status: "fnf_processed", reason_category: "performance", reason_detail: "Terminated after PIP non-completion.", initiated_by: EMP.ananya, approved_by: EMP.ananya, last_working_date: "2026-05-20", notice_period_days: 0, notice_period_waived: 1 },
+    { id: exit.sneha, organization_id: ORG_ID, employee_id: EMP.sneha, exit_type: "resignation", status: "initiated", reason_category: "relocation", reason_detail: "Spouse relocating to Bengaluru.", initiated_by: EMP.sneha, notice_period_days: 30, notice_period_waived: 0 },
+    { id: exit.arjun, organization_id: ORG_ID, employee_id: EMP.arjun, exit_type: "end_of_contract", status: "notice_period", reason_category: "redundancy", reason_detail: "12-month fixed-term contract concluded.", initiated_by: EMP.ananya, resignation_date: "2026-05-01", notice_start_date: "2026-05-01", last_working_date: "2026-05-31", notice_period_days: 30, notice_period_waived: 0 },
+    { id: exit.karthik, organization_id: ORG_ID, employee_id: EMP.karthik, exit_type: "resignation", status: "cancelled", reason_category: "personal", reason_detail: "Personal reasons.", initiated_by: EMP.karthik, notice_period_days: 30, notice_period_waived: 0, revoke_reason: "Withdrew resignation after manager discussion / retention." },
+  ]);
+
+  // ── Clearance records (Priya, multiple statuses) ────────────────────────────
+  await knex("clearance_records").insert([
+    { id: uuidv4(), exit_request_id: exit.priya, department_id: clrDept.it, status: "approved", approved_by: EMP.ananya, approved_at: knex.fn.now(), remarks: "All assets returned, accounts deactivated.", pending_amount: 0 },
+    { id: uuidv4(), exit_request_id: exit.priya, department_id: clrDept.finance, status: "rejected", remarks: "Outstanding travel advance to be recovered in FnF.", pending_amount: 1200000 },
+    { id: uuidv4(), exit_request_id: exit.priya, department_id: clrDept.hr, status: "pending", pending_amount: 0 },
+    { id: uuidv4(), exit_request_id: exit.priya, department_id: clrDept.manager, status: "approved", approved_by: EMP.vikram, approved_at: knex.fn.now(), remarks: "Knowledge transfer complete.", pending_amount: 0 },
+    { id: uuidv4(), exit_request_id: exit.priya, department_id: clrDept.library, status: "waived", remarks: "Not applicable for engineering team.", pending_amount: 0 },
+    { id: uuidv4(), exit_request_id: exit.priya, department_id: clrDept.security, status: "pending", pending_amount: 0 },
+  ]);
+
+  // ── Exit interviews (+ responses for the completed one) ─────────────────────
+  const rahulInterview = uuidv4();
+  await knex("exit_interviews").insert([
+    { id: uuidv4(), exit_request_id: exit.priya, template_id: interviewTpl, interviewer_id: EMP.meera, scheduled_date: "2026-05-28", status: "scheduled" },
+    { id: rahulInterview, exit_request_id: exit.rahul, template_id: interviewTpl, interviewer_id: EMP.meera, scheduled_date: "2026-05-08", completed_date: "2026-05-10", status: "completed", overall_rating: 3, summary: "Cited compensation and limited growth. Praised team culture and manager support. Would consider returning if comp gap closes." },
+    { id: uuidv4(), exit_request_id: exit.vikram, interviewer_id: null, status: "skipped" },
+  ]);
+  await knex("exit_interview_responses").insert([
+    { id: uuidv4(), interview_id: rahulInterview, question_id: q.reason, answer_text: "Better compensation elsewhere." },
+    { id: uuidv4(), interview_id: rahulInterview, question_id: q.experience, answer_rating: 4 },
+    { id: uuidv4(), interview_id: rahulInterview, question_id: q.recommend, answer_text: "Yes" },
+    { id: uuidv4(), interview_id: rahulInterview, question_id: q.mgmt, answer_rating: 3 },
+  ]);
+
+  // ── F&F settlements (paise) ─────────────────────────────────────────────────
+  await knex("fnf_settlements").insert([
+    { id: uuidv4(), exit_request_id: exit.priya, status: "calculated", basic_salary_due: 4500000, leave_encashment: 1800000, bonus_due: 0, gratuity: 0, notice_pay_recovery: 0, other_deductions: 0, other_earnings: 0, total_payable: 6300000, calculated_by: EMP.ananya },
+    { id: uuidv4(), exit_request_id: exit.rahul, status: "approved", basic_salary_due: 5000000, leave_encashment: 1200000, bonus_due: 0, gratuity: 0, notice_pay_recovery: 0, other_deductions: 0, other_earnings: 0, total_payable: 6200000, calculated_by: EMP.ananya, approved_by: EMP.ananya },
+    { id: uuidv4(), exit_request_id: exit.divya, status: "paid", basic_salary_due: 6000000, leave_encashment: 3000000, bonus_due: 0, gratuity: 9750000, notice_pay_recovery: 0, other_deductions: 0, other_earnings: 0, total_payable: 18750000, calculated_by: EMP.ananya, approved_by: EMP.ananya, paid_date: "2026-04-05", remarks: "Payment ref: NEFT-FNF-2026-0042" },
+    { id: uuidv4(), exit_request_id: exit.vikram, status: "calculated", basic_salary_due: 4000000, leave_encashment: 0, bonus_due: 0, gratuity: 0, notice_pay_recovery: 2000000, other_deductions: 1200000, other_earnings: 0, total_payable: 800000, calculated_by: EMP.ananya, remarks: "Notice waived by employer; travel advance recovered." },
+  ]);
+
+  // ── Asset returns (Priya + Rahul, various statuses) ─────────────────────────
+  await knex("asset_returns").insert([
+    { id: uuidv4(), exit_request_id: exit.priya, category: "laptop", asset_name: "Dell Latitude 5430", asset_tag: "LAP-2231", status: "returned", returned_date: "2026-05-30", verified_by: EMP.ananya, condition_notes: "Good condition.", replacement_cost: 8500000 },
+    { id: uuidv4(), exit_request_id: exit.priya, category: "phone", asset_name: "iPhone 13", asset_tag: "MOB-0098", status: "damaged", condition_notes: "Cracked screen; recovery deducted in FnF.", replacement_cost: 6500000 },
+    { id: uuidv4(), exit_request_id: exit.rahul, category: "id_card", asset_name: "Employee ID Badge", asset_tag: "ID-1145", status: "returned", returned_date: "2026-05-15", verified_by: EMP.ananya, replacement_cost: 0 },
+    { id: uuidv4(), exit_request_id: exit.rahul, category: "access_card", asset_name: "Building Access Card", asset_tag: "AC-3320", status: "pending", replacement_cost: 0 },
+    { id: uuidv4(), exit_request_id: exit.rahul, category: "phone", asset_name: "Samsung A52", asset_tag: "MOB-0210", status: "lost", condition_notes: "Reported lost; replacement cost recovered.", replacement_cost: 3000000 },
+  ]);
+
+  // ── Knowledge transfers (+ items) ───────────────────────────────────────────
+  const priyaKt = uuidv4();
+  await knex("knowledge_transfers").insert([
+    { id: priyaKt, exit_request_id: exit.priya, assignee_id: EMP.rahul, status: "in_progress", due_date: "2026-05-29", notes: "Handover of Payments microservice ownership." },
+    { id: uuidv4(), exit_request_id: exit.rahul, assignee_id: EMP.sneha, status: "completed", completed_date: "2026-05-12", notes: "Full handover signed off by manager." },
+    { id: uuidv4(), exit_request_id: exit.sneha, assignee_id: null, status: "not_started" },
+  ]);
+  await knex("kt_items").insert([
+    { id: uuidv4(), kt_id: priyaKt, title: "Document payment-gateway integration", status: "completed", document_url: "https://wiki.internal/kt/priya-payments", completed_at: knex.fn.now() },
+    { id: uuidv4(), kt_id: priyaKt, title: "Pair-program on on-call runbook", status: "in_progress" },
+    { id: uuidv4(), kt_id: priyaKt, title: "Transfer repo & cloud access ownership", status: "not_started" },
+  ]);
+
+  // eslint-disable-next-line no-console
+  console.log(`[seed] emp-exit dummy data inserted for organization_id=${ORG_ID} (7 exit requests + clearances, interviews, F&F, assets, KT).`);
+}


### PR DESCRIPTION
## Summary

Implements the **Knowledge Transfer (KT)** tab on the exit detail page, replacing the *"Knowledge Transfer - coming soon"* placeholder. Frontend-only - the `/kt` backend endpoints already exist.

## Changes (`ExitDetailPage.tsx`)

- Loads the KT plan + items via `GET /kt/exit/:id` when the KT tab is opened.
- Renders: plan **status** badge, **due date**, **notes**, a **progress bar**, and the **item list**.
- Each item shows its status with actions:
  - **Start** (not_started ? in_progress)
  - **Mark Complete** (? completed)
  - via `PUT /kt/items/:id`, with toast feedback.
- Graceful empty states when no KT plan / no items exist.
- Each item can link out to its document (`document_url`) when present.

## Verification

- `tsc --noEmit` passes (no type errors).
- Verified against seeded data - e.g. Priya's exit has an `in_progress` KT plan with 3 items, which renders with progress and working Start/Complete actions.

## Dependency / note

- This branch is **stacked on `feat/exit-detail-edit-and-confirm-dialog` (PR #26)** - it builds on that branch's version of `ExitDetailPage.tsx`. Merge #26 first; afterward this diff is just the KT tab. (If preferred, I can rebase onto `main` once #26 lands.)
- The backend `getKT` returns `assignee_id` but does not enrich the assignee's name from empcloud, so the assignee name is omitted (guarded, no crash). A small `users` join could add it in a follow-up.