### PR TITLE
feat(exit): implement Asset Returns tab

### DIFF
--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -108,6 +108,7 @@ export function ExitDetailPage() {
   const [buyout, setBuyout] = useState<any>(null);
   const [kt, setKt] = useState<any>(null);
   const [fnf, setFnf] = useState<any>(null);
+  const [assets, setAssets] = useState<any[] | null>(null);
   const [letters, setLetters] = useState<any[] | null>(null);
   const [letterTemplates, setLetterTemplates] = useState<any[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
@@ -135,6 +136,7 @@ export function ExitDetailPage() {
     if (activeTab === "buyout") loadBuyout();
     if (activeTab === "kt") loadKt();
     if (activeTab === "fnf") loadFnf();
+    if (activeTab === "assets") loadAssets();
     if (activeTab === "letters") loadLetters();
   }, [activeTab, id, exit]);
 
@@ -321,6 +323,15 @@ export function ExitDetailPage() {
     }
   }
 
+  async function loadAssets() {
+    try {
+      const res = await apiGet<any[]>(`/assets/exit/${id}`);
+      setAssets(res.data ?? []);
+    } catch {
+      setAssets([]);
+    }
+  }
+
   async function handleKtItemUpdate(itemId: string, status: string) {
     try {
       await apiPut(`/kt/items/${itemId}`, { status });
@@ -463,7 +474,9 @@ export function ExitDetailPage() {
           <FnFTab fnf={fnf} exitId={id!} onReload={loadFnf} onExitChanged={loadExit} />
         )}
         {activeTab === "buyout" && <BuyoutTab buyout={buyout} exitId={id!} onReload={loadBuyout} />}
-        {activeTab === "assets" && <PlaceholderTab name="Asset Returns" />}
+        {activeTab === "assets" && (
+          <AssetsTab assets={assets} exitId={id!} onReload={loadAssets} />
+        )}
         {activeTab === "kt" && <KtTab kt={kt} onUpdateItem={handleKtItemUpdate} />}
         {activeTab === "letters" && (
           <LettersTab
@@ -1240,6 +1253,216 @@ function FnFTab({
         onConfirm={() => { if (pendingAction === "approve") handleApprove(); else handleCalculate(); }}
         onCancel={() => setPendingAction(null)}
       />
+    </div>
+  );
+}
+
+const ASSET_STATUS_COLORS: Record<string, string> = {
+  pending: "bg-gray-100 text-gray-600",
+  returned: "bg-green-100 text-green-700",
+  damaged: "bg-amber-100 text-amber-700",
+  lost: "bg-red-100 text-red-700",
+  waived: "bg-blue-100 text-blue-700",
+};
+
+const ASSET_CATEGORIES: { value: string; label: string }[] = [
+  { value: "laptop", label: "Laptop" },
+  { value: "phone", label: "Phone" },
+  { value: "id_card", label: "ID Card" },
+  { value: "access_card", label: "Access Card" },
+  { value: "vehicle", label: "Vehicle" },
+  { value: "furniture", label: "Furniture" },
+  { value: "other", label: "Other" },
+];
+
+const ASSET_STATUSES = ["pending", "returned", "damaged", "lost", "waived"];
+
+function AssetsTab({
+  assets,
+  exitId,
+  onReload,
+}: {
+  assets: any[] | null;
+  exitId: string;
+  onReload: () => void;
+}) {
+  const [showAdd, setShowAdd] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [form, setForm] = useState({ category: "laptop", asset_name: "", asset_tag: "", replacement_cost: "" });
+
+  async function handleAdd() {
+    if (!form.asset_name.trim()) {
+      toast.error("Asset name is required");
+      return;
+    }
+    setSaving(true);
+    try {
+      await apiPost(`/assets/exit/${exitId}`, {
+        category: form.category,
+        asset_name: form.asset_name.trim(),
+        asset_tag: form.asset_tag.trim() || undefined,
+        replacement_cost: form.replacement_cost
+          ? Math.round(parseFloat(form.replacement_cost) * 100)
+          : undefined,
+      });
+      setForm({ category: "laptop", asset_name: "", asset_tag: "", replacement_cost: "" });
+      setShowAdd(false);
+      onReload();
+      toast.success("Asset added");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to add asset");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleStatusChange(assetId: string, status: string) {
+    setBusyId(assetId);
+    try {
+      // When marking returned, stamp today's date so the record is complete.
+      const body: Record<string, any> = { status };
+      if (status === "returned") body.returned_date = new Date().toISOString().slice(0, 10);
+      await apiPut(`/assets/${assetId}`, body);
+      onReload();
+      toast.success("Asset updated");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to update asset");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const list = assets ?? [];
+  const isLoading = assets === null;
+
+  return (
+    <div className="space-y-5">
+      {/* Add control */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-700">Company Assets</h3>
+        <button
+          onClick={() => setShowAdd((v) => !v)}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+        >
+          <Package className="h-3.5 w-3.5" />
+          {showAdd ? "Close" : "Add Asset"}
+        </button>
+      </div>
+
+      {showAdd && (
+        <div className="grid grid-cols-1 gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Category</label>
+            <select
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            >
+              {ASSET_CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Asset Name</label>
+            <input
+              value={form.asset_name}
+              onChange={(e) => setForm({ ...form, asset_name: e.target.value })}
+              placeholder="e.g. Dell Latitude 5430"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Asset Tag</label>
+            <input
+              value={form.asset_tag}
+              onChange={(e) => setForm({ ...form, asset_tag: e.target.value })}
+              placeholder="e.g. LAP-2231"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Replacement Cost (INR)</label>
+            <input
+              type="number"
+              value={form.replacement_cost}
+              onChange={(e) => setForm({ ...form, replacement_cost: e.target.value })}
+              placeholder="0"
+              step="0.01"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <div className="sm:col-span-2 flex justify-end">
+            <button
+              onClick={handleAdd}
+              disabled={saving}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+            >
+              {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+              Add Asset
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Asset list */}
+      {isLoading ? (
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-rose-600" />
+        </div>
+      ) : list.length === 0 ? (
+        <div className="py-10 text-center">
+          <Package className="mx-auto mb-3 h-10 w-10 text-gray-300" />
+          <p className="text-sm text-gray-500">No assets recorded for this exit.</p>
+          <p className="text-xs text-gray-400">Use "Add Asset" above to track company property to be returned.</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-100">
+          {list.map((a) => {
+            const cat = ASSET_CATEGORIES.find((c) => c.value === a.category);
+            return (
+              <div key={a.id} className="flex items-center justify-between py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900">{a.asset_name}</p>
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    {cat?.label || a.category}
+                    {a.asset_tag ? ` · ${a.asset_tag}` : ""}
+                    {a.replacement_cost ? ` · ${formatINR(a.replacement_cost)}` : ""}
+                    {a.returned_date ? ` · Returned ${formatDate(a.returned_date)}` : ""}
+                  </p>
+                  {a.condition_notes && (
+                    <p className="mt-0.5 text-xs italic text-gray-400">{a.condition_notes}</p>
+                  )}
+                </div>
+                <div className="ml-4 flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "inline-flex rounded-full px-2 py-0.5 text-xs font-medium",
+                      ASSET_STATUS_COLORS[a.status] || "bg-gray-100 text-gray-600",
+                    )}
+                  >
+                    {a.status}
+                  </span>
+                  {busyId === a.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+                  ) : (
+                    <select
+                      value={a.status}
+                      onChange={(e) => handleStatusChange(a.id, e.target.value)}
+                      className="rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-rose-400 focus:outline-none"
+                    >
+                      {ASSET_STATUSES.map((s) => (
+                        <option key={s} value={s}>{s}</option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -17,6 +17,8 @@ import {
   Clock,
   Pencil,
   Eye,
+  Banknote,
+  RefreshCw,
 } from "lucide-react";
 import { Link as RouterLink } from "react-router-dom";
 import toast from "react-hot-toast";
@@ -105,6 +107,7 @@ export function ExitDetailPage() {
   const [clearance, setClearance] = useState<any>(null);
   const [buyout, setBuyout] = useState<any>(null);
   const [kt, setKt] = useState<any>(null);
+  const [fnf, setFnf] = useState<any>(null);
   const [letters, setLetters] = useState<any[] | null>(null);
   const [letterTemplates, setLetterTemplates] = useState<any[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
@@ -131,6 +134,7 @@ export function ExitDetailPage() {
     if (activeTab === "clearance") loadClearance();
     if (activeTab === "buyout") loadBuyout();
     if (activeTab === "kt") loadKt();
+    if (activeTab === "fnf") loadFnf();
     if (activeTab === "letters") loadLetters();
   }, [activeTab, id, exit]);
 
@@ -307,6 +311,16 @@ export function ExitDetailPage() {
     }
   }
 
+  async function loadFnf() {
+    try {
+      // GET returns { data: null } (not 404) when no FnF has been calculated.
+      const res = await apiGet<any>(`/fnf/exit/${id}`);
+      setFnf(res.data);
+    } catch {
+      setFnf(null);
+    }
+  }
+
   async function handleKtItemUpdate(itemId: string, status: string) {
     try {
       await apiPut(`/kt/items/${itemId}`, { status });
@@ -445,7 +459,9 @@ export function ExitDetailPage() {
           />
         )}
         {activeTab === "interview" && <PlaceholderTab name="Exit Interview" />}
-        {activeTab === "fnf" && <PlaceholderTab name="Full & Final Settlement" />}
+        {activeTab === "fnf" && (
+          <FnFTab fnf={fnf} exitId={id!} onReload={loadFnf} onExitChanged={loadExit} />
+        )}
         {activeTab === "buyout" && <BuyoutTab buyout={buyout} exitId={id!} onReload={loadBuyout} />}
         {activeTab === "assets" && <PlaceholderTab name="Asset Returns" />}
         {activeTab === "kt" && <KtTab kt={kt} onUpdateItem={handleKtItemUpdate} />}
@@ -900,6 +916,332 @@ function formatINR(amountPaise: number): string {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(rupees);
+}
+
+const FNF_STATUS_COLORS: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-600",
+  calculated: "bg-blue-100 text-blue-700",
+  approved: "bg-green-100 text-green-700",
+  paid: "bg-emerald-100 text-emerald-700",
+};
+
+function FnFTab({
+  fnf,
+  exitId,
+  onReload,
+  onExitChanged,
+}: {
+  fnf: any;
+  exitId: string;
+  onReload: () => void;
+  onExitChanged: () => void;
+}) {
+  const [actionLoading, setActionLoading] = useState(false);
+  const [basicSalaryDue, setBasicSalaryDue] = useState(0);
+  const [leaveEncashment, setLeaveEncashment] = useState(0);
+  const [gratuity, setGratuity] = useState(0);
+  const [bonusDue, setBonusDue] = useState(0);
+  const [otherEarnings, setOtherEarnings] = useState(0);
+  const [noticePayRecovery, setNoticePayRecovery] = useState(0);
+  const [otherDeductions, setOtherDeductions] = useState(0);
+  const [remarks, setRemarks] = useState("");
+  const [showPay, setShowPay] = useState(false);
+  const [payRef, setPayRef] = useState("");
+  const [pendingAction, setPendingAction] = useState<null | "recalculate" | "approve">(null);
+
+  // The parent owns the fetch; seed the editable fields whenever fnf changes.
+  useEffect(() => {
+    if (!fnf) return;
+    setBasicSalaryDue(fnf.basic_salary_due ?? 0);
+    setLeaveEncashment(fnf.leave_encashment ?? 0);
+    setGratuity(fnf.gratuity ?? 0);
+    setBonusDue(fnf.bonus_due ?? 0);
+    setOtherEarnings(fnf.other_earnings ?? 0);
+    setNoticePayRecovery(fnf.notice_pay_recovery ?? 0);
+    setOtherDeductions(fnf.other_deductions ?? 0);
+    setRemarks(fnf.remarks || "");
+  }, [fnf]);
+
+  const isPaid = fnf?.status === "paid";
+  const isEditable = !isPaid;
+  const totalEarnings = basicSalaryDue + leaveEncashment + gratuity + bonusDue + otherEarnings;
+  const totalDeductions = noticePayRecovery + otherDeductions;
+  const netPayable = totalEarnings - totalDeductions;
+
+  async function handleCalculate() {
+    setActionLoading(true);
+    try {
+      await apiPost(`/fnf/exit/${exitId}/calculate`);
+      onReload();
+      setPendingAction(null);
+      toast.success("FnF calculated");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to calculate FnF");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleSave() {
+    setActionLoading(true);
+    try {
+      await apiPut(`/fnf/exit/${exitId}`, {
+        basic_salary_due: basicSalaryDue,
+        leave_encashment: leaveEncashment,
+        gratuity,
+        bonus_due: bonusDue,
+        other_earnings: otherEarnings,
+        notice_pay_recovery: noticePayRecovery,
+        other_deductions: otherDeductions,
+        remarks: remarks || undefined,
+      });
+      onReload();
+      toast.success("FnF updated");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to save FnF");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleApprove() {
+    setActionLoading(true);
+    try {
+      await apiPost(`/fnf/exit/${exitId}/approve`);
+      onReload();
+      setPendingAction(null);
+      toast.success("FnF approved");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to approve FnF");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleMarkPaid() {
+    if (!payRef.trim()) return;
+    setActionLoading(true);
+    try {
+      await apiPost(`/fnf/exit/${exitId}/mark-paid`, { payment_reference: payRef.trim() });
+      setShowPay(false);
+      setPayRef("");
+      onReload();
+      onExitChanged(); // mark-paid flips the parent exit to fnf_processed
+      toast.success("FnF marked as paid");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to mark as paid");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  const AmountField = ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: number;
+    onChange: (v: number) => void;
+  }) => (
+    <div className="flex items-center justify-between border-b border-gray-100 py-2.5 last:border-0">
+      <span className="text-sm text-gray-700">{label}</span>
+      <div className="flex items-center gap-1">
+        <span className="text-xs text-gray-400">INR</span>
+        <input
+          type="number"
+          value={value / 100}
+          onChange={(e) => onChange(Math.round(parseFloat(e.target.value || "0") * 100))}
+          disabled={!isEditable}
+          step="0.01"
+          className="w-32 rounded border border-gray-300 px-2 py-1 text-right text-sm font-mono focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500 disabled:bg-gray-50 disabled:text-gray-500"
+        />
+      </div>
+    </div>
+  );
+
+  // Empty state — no FnF calculated yet.
+  if (!fnf) {
+    return (
+      <div className="py-8 text-center">
+        <Calculator className="mx-auto mb-3 h-10 w-10 text-gray-300" />
+        <p className="mb-4 text-sm text-gray-500">No full &amp; final settlement yet.</p>
+        <button
+          onClick={handleCalculate}
+          disabled={actionLoading}
+          className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+        >
+          {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+          Calculate Settlement
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Header + status */}
+      <div className="flex items-center gap-3">
+        <Calculator className="h-5 w-5 text-rose-500" />
+        <h3 className="text-sm font-semibold text-gray-900">Full &amp; Final Settlement</h3>
+        <span
+          className={cn(
+            "inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize",
+            FNF_STATUS_COLORS[fnf.status] || "bg-gray-100 text-gray-600",
+          )}
+        >
+          {fnf.status}
+        </span>
+      </div>
+
+      {isPaid && fnf.paid_date && (
+        <div className="flex items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+          <Banknote className="h-5 w-5 text-emerald-600" />
+          <div>
+            <p className="text-sm font-medium text-emerald-800">Payment Completed</p>
+            <p className="text-xs text-emerald-600">Paid on {formatDate(fnf.paid_date)}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Earnings / Deductions */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-gray-200 p-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-emerald-600">Earnings</h4>
+          <AmountField label="Pending Salary (pro-rata)" value={basicSalaryDue} onChange={setBasicSalaryDue} />
+          <AmountField label="Leave Encashment" value={leaveEncashment} onChange={setLeaveEncashment} />
+          <AmountField label="Gratuity" value={gratuity} onChange={setGratuity} />
+          <AmountField label="Bonus" value={bonusDue} onChange={setBonusDue} />
+          <AmountField label="Other Earnings" value={otherEarnings} onChange={setOtherEarnings} />
+          <div className="mt-2 flex items-center justify-between border-t border-gray-200 pt-2 text-sm font-semibold text-emerald-700">
+            <span>Total Earnings</span><span>{formatINR(totalEarnings)}</span>
+          </div>
+        </div>
+        <div className="rounded-lg border border-gray-200 p-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-red-600">Deductions</h4>
+          <AmountField label="Notice Period Recovery" value={noticePayRecovery} onChange={setNoticePayRecovery} />
+          <AmountField label="Other Deductions" value={otherDeductions} onChange={setOtherDeductions} />
+          <div className="mt-2 flex items-center justify-between border-t border-gray-200 pt-2 text-sm font-semibold text-red-700">
+            <span>Total Deductions</span><span>{formatINR(totalDeductions)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Net payable */}
+      <div
+        className={cn(
+          "flex items-center justify-between rounded-lg p-4",
+          netPayable >= 0 ? "bg-emerald-50 text-emerald-800" : "bg-red-50 text-red-800",
+        )}
+      >
+        <span className="text-sm font-semibold">Net Payable</span>
+        <span className="text-lg font-bold">{formatINR(netPayable)}</span>
+      </div>
+
+      {/* Remarks */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-600">Remarks</label>
+        <textarea
+          value={remarks}
+          onChange={(e) => setRemarks(e.target.value)}
+          disabled={!isEditable}
+          rows={2}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none disabled:bg-gray-50"
+        />
+      </div>
+
+      {isEditable && (
+        <p className="text-xs text-gray-400">
+          Auto-calculation seeds amounts from notice/tenure only — enter the actual salary-based amounts above and Save.
+        </p>
+      )}
+
+      {/* Mark-paid inline input */}
+      {showPay && (
+        <div className="flex flex-wrap items-end gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <div className="flex-1 min-w-[200px]">
+            <label className="mb-1 block text-xs font-medium text-gray-600">Payment reference</label>
+            <input
+              value={payRef}
+              onChange={(e) => setPayRef(e.target.value)}
+              placeholder="e.g. NEFT-FNF-2026-0042"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <button
+            onClick={handleMarkPaid}
+            disabled={!payRef.trim() || actionLoading}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+            Confirm Payment
+          </button>
+          <button
+            onClick={() => { setShowPay(false); setPayRef(""); }}
+            disabled={actionLoading}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Status-driven actions */}
+      {!isPaid && !showPay && (
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gray-100 pt-4">
+          {isEditable && fnf.status !== "approved" && (
+            <button
+              onClick={() => setPendingAction("recalculate")}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              <RefreshCw className="h-4 w-4" /> Recalculate
+            </button>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={actionLoading}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+          >
+            {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />} Save Changes
+          </button>
+          {fnf.status === "calculated" && (
+            <button
+              onClick={() => setPendingAction("approve")}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+            >
+              <CheckCircle className="h-4 w-4" /> Approve
+            </button>
+          )}
+          {fnf.status === "approved" && (
+            <button
+              onClick={() => setShowPay(true)}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              <Banknote className="h-4 w-4" /> Mark Paid
+            </button>
+          )}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={pendingAction !== null}
+        title={pendingAction === "approve" ? "Approve FnF settlement?" : "Recalculate FnF?"}
+        message={
+          pendingAction === "approve"
+            ? "Approving locks the settlement from recalculation. Continue?"
+            : "Recalculating overwrites any manual amount edits with auto-derived values. Continue?"
+        }
+        confirmLabel={pendingAction === "approve" ? "Approve" : "Recalculate"}
+        tone="primary"
+        loading={actionLoading}
+        onConfirm={() => { if (pendingAction === "approve") handleApprove(); else handleCalculate(); }}
+        onCancel={() => setPendingAction(null)}
+      />
+    </div>
+  );
 }
 
 const LETTER_TYPES: Record<string, string> = {


### PR DESCRIPTION
## Summary

Implements the Asset Returns tab on the exit detail page, replacing the "coming soon" placeholder. Frontend-only, against the existing /assets endpoints.

## Changes (ExitDetailPage.tsx)

- Loads assets via GET /assets/exit/:id.
- Lists each asset (name, category, tag, replacement cost in INR, returned date, condition notes) with a status badge: pending / returned / damaged / lost / waived.
- Inline per-asset status dropdown to update via PUT /assets/:assetId. Marking an asset "returned" auto-stamps today's returned_date.
- Collapsible "Add Asset" form (category, name, tag, replacement cost) -> POST /assets/exit/:id. Cost is entered in INR and stored in paise (Math.round(x100)).
- Empty/loading states and toast feedback throughout.

## Verification

- tsc --noEmit passes (no type errors).
- Seeded data exercises multiple statuses: Priya (laptop returned, phone damaged), Rahul (id card returned, access card pending, phone lost). Sneha has none -> empty state.

## Merge order

Stacked on feat/exit-fnf-tab (PR #29) -> #28 -> #27 -> #26, all touching ExitDetailPage.tsx. Recommended merge order: #26 -> #27 -> #28 -> #29 -> this PR. Can rebase onto main if preferred.

This completes all previously "coming soon" exit detail tabs (KT, Letters, FnF, Assets).