### PR TITLE
refactor(settings): redesign Exit Settings UI

### DIFF
--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -108,6 +108,7 @@ export function ExitDetailPage() {
   const [buyout, setBuyout] = useState<any>(null);
   const [kt, setKt] = useState<any>(null);
   const [fnf, setFnf] = useState<any>(null);
+  const [assets, setAssets] = useState<any[] | null>(null);
   const [letters, setLetters] = useState<any[] | null>(null);
   const [letterTemplates, setLetterTemplates] = useState<any[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
@@ -135,6 +136,7 @@ export function ExitDetailPage() {
     if (activeTab === "buyout") loadBuyout();
     if (activeTab === "kt") loadKt();
     if (activeTab === "fnf") loadFnf();
+    if (activeTab === "assets") loadAssets();
     if (activeTab === "letters") loadLetters();
   }, [activeTab, id, exit]);
 
@@ -321,6 +323,15 @@ export function ExitDetailPage() {
     }
   }
 
+  async function loadAssets() {
+    try {
+      const res = await apiGet<any[]>(`/assets/exit/${id}`);
+      setAssets(res.data ?? []);
+    } catch {
+      setAssets([]);
+    }
+  }
+
   async function handleKtItemUpdate(itemId: string, status: string) {
     try {
       await apiPut(`/kt/items/${itemId}`, { status });
@@ -463,7 +474,9 @@ export function ExitDetailPage() {
           <FnFTab fnf={fnf} exitId={id!} onReload={loadFnf} onExitChanged={loadExit} />
         )}
         {activeTab === "buyout" && <BuyoutTab buyout={buyout} exitId={id!} onReload={loadBuyout} />}
-        {activeTab === "assets" && <PlaceholderTab name="Asset Returns" />}
+        {activeTab === "assets" && (
+          <AssetsTab assets={assets} exitId={id!} onReload={loadAssets} />
+        )}
         {activeTab === "kt" && <KtTab kt={kt} onUpdateItem={handleKtItemUpdate} />}
         {activeTab === "letters" && (
           <LettersTab
@@ -1240,6 +1253,216 @@ function FnFTab({
         onConfirm={() => { if (pendingAction === "approve") handleApprove(); else handleCalculate(); }}
         onCancel={() => setPendingAction(null)}
       />
+    </div>
+  );
+}
+
+const ASSET_STATUS_COLORS: Record<string, string> = {
+  pending: "bg-gray-100 text-gray-600",
+  returned: "bg-green-100 text-green-700",
+  damaged: "bg-amber-100 text-amber-700",
+  lost: "bg-red-100 text-red-700",
+  waived: "bg-blue-100 text-blue-700",
+};
+
+const ASSET_CATEGORIES: { value: string; label: string }[] = [
+  { value: "laptop", label: "Laptop" },
+  { value: "phone", label: "Phone" },
+  { value: "id_card", label: "ID Card" },
+  { value: "access_card", label: "Access Card" },
+  { value: "vehicle", label: "Vehicle" },
+  { value: "furniture", label: "Furniture" },
+  { value: "other", label: "Other" },
+];
+
+const ASSET_STATUSES = ["pending", "returned", "damaged", "lost", "waived"];
+
+function AssetsTab({
+  assets,
+  exitId,
+  onReload,
+}: {
+  assets: any[] | null;
+  exitId: string;
+  onReload: () => void;
+}) {
+  const [showAdd, setShowAdd] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [form, setForm] = useState({ category: "laptop", asset_name: "", asset_tag: "", replacement_cost: "" });
+
+  async function handleAdd() {
+    if (!form.asset_name.trim()) {
+      toast.error("Asset name is required");
+      return;
+    }
+    setSaving(true);
+    try {
+      await apiPost(`/assets/exit/${exitId}`, {
+        category: form.category,
+        asset_name: form.asset_name.trim(),
+        asset_tag: form.asset_tag.trim() || undefined,
+        replacement_cost: form.replacement_cost
+          ? Math.round(parseFloat(form.replacement_cost) * 100)
+          : undefined,
+      });
+      setForm({ category: "laptop", asset_name: "", asset_tag: "", replacement_cost: "" });
+      setShowAdd(false);
+      onReload();
+      toast.success("Asset added");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to add asset");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleStatusChange(assetId: string, status: string) {
+    setBusyId(assetId);
+    try {
+      // When marking returned, stamp today's date so the record is complete.
+      const body: Record<string, any> = { status };
+      if (status === "returned") body.returned_date = new Date().toISOString().slice(0, 10);
+      await apiPut(`/assets/${assetId}`, body);
+      onReload();
+      toast.success("Asset updated");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to update asset");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const list = assets ?? [];
+  const isLoading = assets === null;
+
+  return (
+    <div className="space-y-5">
+      {/* Add control */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-700">Company Assets</h3>
+        <button
+          onClick={() => setShowAdd((v) => !v)}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+        >
+          <Package className="h-3.5 w-3.5" />
+          {showAdd ? "Close" : "Add Asset"}
+        </button>
+      </div>
+
+      {showAdd && (
+        <div className="grid grid-cols-1 gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Category</label>
+            <select
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            >
+              {ASSET_CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Asset Name</label>
+            <input
+              value={form.asset_name}
+              onChange={(e) => setForm({ ...form, asset_name: e.target.value })}
+              placeholder="e.g. Dell Latitude 5430"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Asset Tag</label>
+            <input
+              value={form.asset_tag}
+              onChange={(e) => setForm({ ...form, asset_tag: e.target.value })}
+              placeholder="e.g. LAP-2231"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Replacement Cost (INR)</label>
+            <input
+              type="number"
+              value={form.replacement_cost}
+              onChange={(e) => setForm({ ...form, replacement_cost: e.target.value })}
+              placeholder="0"
+              step="0.01"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <div className="sm:col-span-2 flex justify-end">
+            <button
+              onClick={handleAdd}
+              disabled={saving}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+            >
+              {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+              Add Asset
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Asset list */}
+      {isLoading ? (
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-rose-600" />
+        </div>
+      ) : list.length === 0 ? (
+        <div className="py-10 text-center">
+          <Package className="mx-auto mb-3 h-10 w-10 text-gray-300" />
+          <p className="text-sm text-gray-500">No assets recorded for this exit.</p>
+          <p className="text-xs text-gray-400">Use "Add Asset" above to track company property to be returned.</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-100">
+          {list.map((a) => {
+            const cat = ASSET_CATEGORIES.find((c) => c.value === a.category);
+            return (
+              <div key={a.id} className="flex items-center justify-between py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900">{a.asset_name}</p>
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    {cat?.label || a.category}
+                    {a.asset_tag ? ` · ${a.asset_tag}` : ""}
+                    {a.replacement_cost ? ` · ${formatINR(a.replacement_cost)}` : ""}
+                    {a.returned_date ? ` · Returned ${formatDate(a.returned_date)}` : ""}
+                  </p>
+                  {a.condition_notes && (
+                    <p className="mt-0.5 text-xs italic text-gray-400">{a.condition_notes}</p>
+                  )}
+                </div>
+                <div className="ml-4 flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "inline-flex rounded-full px-2 py-0.5 text-xs font-medium",
+                      ASSET_STATUS_COLORS[a.status] || "bg-gray-100 text-gray-600",
+                    )}
+                  >
+                    {a.status}
+                  </span>
+                  {busyId === a.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+                  ) : (
+                    <select
+                      value={a.status}
+                      onChange={(e) => handleStatusChange(a.id, e.target.value)}
+                      className="rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-rose-400 focus:outline-none"
+                    >
+                      {ASSET_STATUSES.map((s) => (
+                        <option key={s} value={s}>{s}</option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -19,6 +19,11 @@ import {
   Eye,
   Banknote,
   RefreshCw,
+  Star,
+  Send,
+  SkipForward,
+  Search,
+  X,
 } from "lucide-react";
 import { Link as RouterLink } from "react-router-dom";
 import toast from "react-hot-toast";
@@ -109,6 +114,8 @@ export function ExitDetailPage() {
   const [kt, setKt] = useState<any>(null);
   const [fnf, setFnf] = useState<any>(null);
   const [assets, setAssets] = useState<any[] | null>(null);
+  const [interview, setInterview] = useState<any>(null);
+  const [interviewTemplates, setInterviewTemplates] = useState<any[]>([]);
   const [letters, setLetters] = useState<any[] | null>(null);
   const [letterTemplates, setLetterTemplates] = useState<any[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
@@ -137,6 +144,7 @@ export function ExitDetailPage() {
     if (activeTab === "kt") loadKt();
     if (activeTab === "fnf") loadFnf();
     if (activeTab === "assets") loadAssets();
+    if (activeTab === "interview") loadInterview();
     if (activeTab === "letters") loadLetters();
   }, [activeTab, id, exit]);
 
@@ -332,6 +340,22 @@ export function ExitDetailPage() {
     }
   }
 
+  async function loadInterview() {
+    try {
+      // GET returns { data: null } (not 404) when no interview is scheduled.
+      const res = await apiGet<any>(`/interviews/exit/${id}`);
+      setInterview(res.data);
+    } catch {
+      setInterview(null);
+    }
+    try {
+      const tplRes = await apiGet<any[]>(`/interviews/templates`);
+      setInterviewTemplates(tplRes.data ?? []);
+    } catch {
+      setInterviewTemplates([]);
+    }
+  }
+
   async function handleKtItemUpdate(itemId: string, status: string) {
     try {
       await apiPut(`/kt/items/${itemId}`, { status });
@@ -469,7 +493,14 @@ export function ExitDetailPage() {
             actionLoading={actionLoading}
           />
         )}
-        {activeTab === "interview" && <PlaceholderTab name="Exit Interview" />}
+        {activeTab === "interview" && (
+          <InterviewTab
+            interview={interview}
+            templates={interviewTemplates}
+            exitId={id!}
+            onReload={loadInterview}
+          />
+        )}
         {activeTab === "fnf" && (
           <FnFTab fnf={fnf} exitId={id!} onReload={loadFnf} onExitChanged={loadExit} />
         )}
@@ -1251,6 +1282,490 @@ function FnFTab({
         tone="primary"
         loading={actionLoading}
         onConfirm={() => { if (pendingAction === "approve") handleApprove(); else handleCalculate(); }}
+        onCancel={() => setPendingAction(null)}
+      />
+    </div>
+  );
+}
+
+const INTERVIEW_STATUS_COLORS: Record<string, string> = {
+  scheduled: "bg-blue-100 text-blue-700",
+  completed: "bg-green-100 text-green-700",
+  skipped: "bg-gray-100 text-gray-600",
+};
+
+function InterviewTab({
+  interview,
+  templates,
+  exitId,
+  onReload,
+}: {
+  interview: any;
+  templates: any[];
+  exitId: string;
+  onReload: () => void;
+}) {
+  const [actionLoading, setActionLoading] = useState(false);
+  const [questions, setQuestions] = useState<any[]>([]);
+  const [answers, setAnswers] = useState<Record<string, { text?: string; rating?: number }>>({});
+  const [overallRating, setOverallRating] = useState(0);
+  const [wouldRecommend, setWouldRecommend] = useState<boolean | null>(null);
+  const [pendingAction, setPendingAction] = useState<null | "complete" | "skip">(null);
+
+  // Schedule form state (not-scheduled state)
+  const [templateId, setTemplateId] = useState("");
+  const [scheduledAt, setScheduledAt] = useState("");
+  const [interviewer, setInterviewer] = useState<any | null>(null);
+  const [intvQuery, setIntvQuery] = useState("");
+  const [intvResults, setIntvResults] = useState<any[]>([]);
+  const [intvSearching, setIntvSearching] = useState(false);
+  const [showIntvResults, setShowIntvResults] = useState(false);
+
+  const isCompleted = interview?.status === "completed";
+  const isSkipped = interview?.status === "skipped";
+  const isReadOnly = isCompleted || isSkipped;
+
+  // Fetch the full ordered question list (GET only returns answered questions
+  // nested in responses[]) and pre-fill answers from any existing responses.
+  useEffect(() => {
+    if (!interview) {
+      setQuestions([]);
+      return;
+    }
+    if (interview.template_id) {
+      apiGet<any>(`/interviews/templates/${interview.template_id}`)
+        .then((r) => setQuestions(r.data?.questions ?? []))
+        .catch(() => setQuestions([]));
+    } else {
+      setQuestions([]);
+    }
+    const filled: Record<string, { text?: string; rating?: number }> = {};
+    for (const resp of interview.responses ?? []) {
+      filled[resp.question_id] = {
+        text: resp.answer_text || undefined,
+        rating: resp.answer_rating || undefined,
+      };
+    }
+    setAnswers(filled);
+    setOverallRating(interview.overall_rating || 0);
+    if (interview.summary?.includes("Would recommend: Yes")) setWouldRecommend(true);
+    else if (interview.summary?.includes("Would recommend: No")) setWouldRecommend(false);
+    else setWouldRecommend(null);
+  }, [interview]);
+
+  // Debounced interviewer search (only used in the schedule form).
+  useEffect(() => {
+    if (interview || interviewer) return;
+    const q = intvQuery.trim();
+    if (!q) { setIntvResults([]); return; }
+    const handle = setTimeout(async () => {
+      setIntvSearching(true);
+      try {
+        const res = await apiGet<any[]>("/users/search", { q });
+        if (intvQuery.trim() === q) setIntvResults(res.data ?? []);
+      } catch { /* ignore */ } finally {
+        setIntvSearching(false);
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [intvQuery, interviewer, interview]);
+
+  function handleAnswerChange(qid: string, field: "text" | "rating", value: string | number) {
+    setAnswers((prev) => ({ ...prev, [qid]: { ...prev[qid], [field]: value } }));
+  }
+
+  async function handleSchedule() {
+    if (!templateId || !interviewer || !scheduledAt) {
+      toast.error("Select a template, an interviewer, and a date");
+      return;
+    }
+    setActionLoading(true);
+    try {
+      await apiPost(`/interviews/exit/${exitId}`, {
+        template_id: templateId,
+        conducted_by: Number(interviewer.id),
+        scheduled_at: scheduledAt,
+      });
+      toast.success("Interview scheduled");
+      onReload();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to schedule interview");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleSubmitResponses() {
+    setActionLoading(true);
+    try {
+      const responses = questions.map((q) => ({
+        question_id: q.id,
+        answer_text: answers[q.id]?.text || undefined,
+        answer_rating: answers[q.id]?.rating || undefined,
+      }));
+      await apiPost(`/interviews/exit/${exitId}/responses`, {
+        responses,
+        overall_rating: overallRating || undefined,
+        would_recommend: wouldRecommend,
+      });
+      toast.success("Responses saved");
+      onReload();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to save responses");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function runComplete() {
+    setActionLoading(true);
+    try {
+      await apiPost(`/interviews/exit/${exitId}/complete`);
+      setPendingAction(null);
+      toast.success("Interview completed");
+      onReload();
+    } catch (err: any) {
+      setPendingAction(null);
+      toast.error(err?.response?.data?.error?.message || "Failed to complete interview");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function runSkip() {
+    setActionLoading(true);
+    try {
+      await apiPost(`/interviews/exit/${exitId}/skip`);
+      setPendingAction(null);
+      toast.success("Interview skipped");
+      onReload();
+    } catch (err: any) {
+      setPendingAction(null);
+      toast.error(err?.response?.data?.error?.message || "Failed to skip interview");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  function renderQuestionInput(q: any) {
+    const answer = answers[q.id] || {};
+    if (q.question_type === "rating") {
+      return (
+        <div className="flex gap-1">
+          {[1, 2, 3, 4, 5].map((star) => (
+            <button
+              key={star}
+              type="button"
+              disabled={isReadOnly}
+              onClick={() => handleAnswerChange(q.id, "rating", star)}
+              className="disabled:cursor-default"
+            >
+              <Star
+                className={cn(
+                  "h-6 w-6",
+                  (answer.rating || 0) >= star ? "fill-amber-400 text-amber-400" : "text-gray-300",
+                )}
+              />
+            </button>
+          ))}
+        </div>
+      );
+    }
+    if (q.question_type === "yes_no") {
+      return (
+        <div className="flex gap-2">
+          {["Yes", "No"].map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              disabled={isReadOnly}
+              onClick={() => handleAnswerChange(q.id, "text", opt)}
+              className={cn(
+                "rounded-lg border px-4 py-1.5 text-sm font-medium disabled:cursor-default",
+                answer.text === opt
+                  ? "border-rose-500 bg-rose-50 text-rose-700"
+                  : "border-gray-300 text-gray-700 hover:bg-gray-50",
+              )}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      );
+    }
+    if (q.question_type === "multiple_choice") {
+      let opts: string[] = [];
+      if (q.options) {
+        try {
+          const p = JSON.parse(q.options);
+          opts = Array.isArray(p) ? p.map(String) : [];
+        } catch {
+          opts = String(q.options).split(",").map((o) => o.trim());
+        }
+      }
+      return (
+        <div className="space-y-1.5">
+          {opts.map((opt) => (
+            <label key={opt} className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name={`q-${q.id}`}
+                disabled={isReadOnly}
+                checked={answer.text === opt}
+                onChange={() => handleAnswerChange(q.id, "text", opt)}
+              />
+              {opt}
+            </label>
+          ))}
+        </div>
+      );
+    }
+    // text
+    return (
+      <textarea
+        value={answer.text || ""}
+        disabled={isReadOnly}
+        onChange={(e) => handleAnswerChange(q.id, "text", e.target.value)}
+        rows={2}
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none disabled:bg-gray-50"
+      />
+    );
+  }
+
+  // ── State A: not scheduled ──────────────────────────────────────────────────
+  if (!interview) {
+    return (
+      <div className="space-y-5">
+        <div className="py-6 text-center">
+          <MessageSquare className="mx-auto mb-3 h-10 w-10 text-gray-300" />
+          <p className="text-sm text-gray-500">No exit interview scheduled.</p>
+        </div>
+        <div className="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
+          {templates.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              No interview templates available. Create one in Interview Templates first.
+            </p>
+          ) : (
+            <>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-gray-600">Template</label>
+                <select
+                  value={templateId}
+                  onChange={(e) => setTemplateId(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+                >
+                  <option value="" disabled>Select a template…</option>
+                  {templates.map((t) => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-gray-600">Interviewer</label>
+                {interviewer ? (
+                  <div className="flex items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2">
+                    <span className="text-sm text-gray-800">
+                      {interviewer.first_name} {interviewer.last_name}
+                      <span className="ml-1 text-xs text-gray-400">
+                        {interviewer.emp_code || interviewer.email}
+                      </span>
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => { setInterviewer(null); setIntvQuery(""); setIntvResults([]); }}
+                      className="text-gray-400 hover:text-gray-600"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                ) : (
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                    <input
+                      value={intvQuery}
+                      onChange={(e) => { setIntvQuery(e.target.value); setShowIntvResults(true); }}
+                      onFocus={() => setShowIntvResults(true)}
+                      onBlur={() => setTimeout(() => setShowIntvResults(false), 150)}
+                      placeholder="Search employee by name or email…"
+                      className="w-full rounded-lg border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-rose-400 focus:outline-none"
+                    />
+                    {showIntvResults && (intvSearching || intvResults.length > 0) && (
+                      <div className="absolute z-10 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+                        {intvSearching ? (
+                          <div className="px-3 py-2 text-xs text-gray-400">Searching…</div>
+                        ) : (
+                          intvResults.map((u) => (
+                            <button
+                              key={u.id}
+                              type="button"
+                              onMouseDown={() => { setInterviewer(u); setShowIntvResults(false); }}
+                              className="block w-full px-3 py-2 text-left text-sm hover:bg-gray-50"
+                            >
+                              {u.first_name} {u.last_name}
+                              <span className="ml-1 text-xs text-gray-400">{u.emp_code || u.email}</span>
+                            </button>
+                          ))
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-gray-600">Scheduled Date</label>
+                <input
+                  type="date"
+                  value={scheduledAt}
+                  onChange={(e) => setScheduledAt(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+                />
+              </div>
+              <div className="flex justify-end">
+                <button
+                  onClick={handleSchedule}
+                  disabled={actionLoading || !templateId || !interviewer || !scheduledAt}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+                >
+                  {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+                  Schedule Interview
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── State B/C: scheduled (editable) or completed/skipped (read-only) ────────
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
+        <MessageSquare className="h-5 w-5 text-rose-500" />
+        <h3 className="text-sm font-semibold text-gray-900">Exit Interview</h3>
+        <span
+          className={cn(
+            "inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize",
+            INTERVIEW_STATUS_COLORS[interview.status] || "bg-gray-100 text-gray-600",
+          )}
+        >
+          {interview.status}
+        </span>
+        {interview.scheduled_date && <span>Scheduled: {formatDate(interview.scheduled_date)}</span>}
+        {interview.completed_date && <span>Completed: {formatDate(interview.completed_date)}</span>}
+      </div>
+
+      {isSkipped && (
+        <p className="rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-500">This interview was skipped.</p>
+      )}
+
+      {questions.length === 0 ? (
+        <p className="py-4 text-center text-sm text-gray-400">No questions on this interview template.</p>
+      ) : (
+        <>
+          <div className="space-y-4">
+            {questions.map((q, idx) => (
+              <div key={q.id} className="rounded-lg border border-gray-200 p-4">
+                <p className="mb-2 text-sm font-medium text-gray-900">
+                  {idx + 1}. {q.question_text}
+                  {q.is_required ? <span className="ml-1 text-red-500">*</span> : null}
+                </p>
+                {renderQuestionInput(q)}
+              </div>
+            ))}
+          </div>
+
+          {/* Overall feedback */}
+          <div className="rounded-lg border border-gray-200 p-4 space-y-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-gray-600">Overall Rating (1–10)</label>
+              <div className="flex flex-wrap gap-1">
+                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    disabled={isReadOnly}
+                    onClick={() => setOverallRating(n)}
+                    className={cn(
+                      "h-8 w-8 rounded-md border text-xs font-medium disabled:cursor-default",
+                      overallRating === n
+                        ? "border-rose-500 bg-rose-500 text-white"
+                        : "border-gray-300 text-gray-600 hover:bg-gray-50",
+                    )}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-gray-600">Would recommend as an employer?</label>
+              <div className="flex gap-2">
+                {[{ v: true, l: "Yes" }, { v: false, l: "No" }].map(({ v, l }) => (
+                  <button
+                    key={l}
+                    type="button"
+                    disabled={isReadOnly}
+                    onClick={() => setWouldRecommend(v)}
+                    className={cn(
+                      "rounded-lg border px-4 py-1.5 text-sm font-medium disabled:cursor-default",
+                      wouldRecommend === v
+                        ? "border-rose-500 bg-rose-50 text-rose-700"
+                        : "border-gray-300 text-gray-700 hover:bg-gray-50",
+                    )}
+                  >
+                    {l}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Actions (scheduled only) */}
+      {!isReadOnly && (
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gray-100 pt-4">
+          <button
+            onClick={() => setPendingAction("skip")}
+            disabled={actionLoading}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            <SkipForward className="h-4 w-4" /> Skip
+          </button>
+          {questions.length > 0 && (
+            <button
+              onClick={handleSubmitResponses}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+            >
+              {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+              <Send className="h-4 w-4" /> Save Responses
+            </button>
+          )}
+          <button
+            onClick={() => setPendingAction("complete")}
+            disabled={actionLoading}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+          >
+            <CheckCircle className="h-4 w-4" /> Complete
+          </button>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={pendingAction !== null}
+        title={pendingAction === "skip" ? "Skip this interview?" : "Complete this interview?"}
+        message={
+          pendingAction === "skip"
+            ? "Skipping marks the interview as skipped. This cannot be undone."
+            : "Completing locks the interview from further changes. Continue?"
+        }
+        confirmLabel={pendingAction === "skip" ? "Skip" : "Complete"}
+        tone={pendingAction === "skip" ? "danger" : "primary"}
+        loading={actionLoading}
+        onConfirm={() => { if (pendingAction === "skip") runSkip(); else runComplete(); }}
         onCancel={() => setPendingAction(null)}
       />
     </div>

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -17,6 +17,8 @@ import {
   Clock,
   Pencil,
   Eye,
+  Banknote,
+  RefreshCw,
 } from "lucide-react";
 import { Link as RouterLink } from "react-router-dom";
 import toast from "react-hot-toast";
@@ -105,6 +107,7 @@ export function ExitDetailPage() {
   const [clearance, setClearance] = useState<any>(null);
   const [buyout, setBuyout] = useState<any>(null);
   const [kt, setKt] = useState<any>(null);
+  const [fnf, setFnf] = useState<any>(null);
   const [letters, setLetters] = useState<any[] | null>(null);
   const [letterTemplates, setLetterTemplates] = useState<any[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
@@ -131,6 +134,7 @@ export function ExitDetailPage() {
     if (activeTab === "clearance") loadClearance();
     if (activeTab === "buyout") loadBuyout();
     if (activeTab === "kt") loadKt();
+    if (activeTab === "fnf") loadFnf();
     if (activeTab === "letters") loadLetters();
   }, [activeTab, id, exit]);
 
@@ -307,6 +311,16 @@ export function ExitDetailPage() {
     }
   }
 
+  async function loadFnf() {
+    try {
+      // GET returns { data: null } (not 404) when no FnF has been calculated.
+      const res = await apiGet<any>(`/fnf/exit/${id}`);
+      setFnf(res.data);
+    } catch {
+      setFnf(null);
+    }
+  }
+
   async function handleKtItemUpdate(itemId: string, status: string) {
     try {
       await apiPut(`/kt/items/${itemId}`, { status });
@@ -445,7 +459,9 @@ export function ExitDetailPage() {
           />
         )}
         {activeTab === "interview" && <PlaceholderTab name="Exit Interview" />}
-        {activeTab === "fnf" && <PlaceholderTab name="Full & Final Settlement" />}
+        {activeTab === "fnf" && (
+          <FnFTab fnf={fnf} exitId={id!} onReload={loadFnf} onExitChanged={loadExit} />
+        )}
         {activeTab === "buyout" && <BuyoutTab buyout={buyout} exitId={id!} onReload={loadBuyout} />}
         {activeTab === "assets" && <PlaceholderTab name="Asset Returns" />}
         {activeTab === "kt" && <KtTab kt={kt} onUpdateItem={handleKtItemUpdate} />}
@@ -900,6 +916,332 @@ function formatINR(amountPaise: number): string {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(rupees);
+}
+
+const FNF_STATUS_COLORS: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-600",
+  calculated: "bg-blue-100 text-blue-700",
+  approved: "bg-green-100 text-green-700",
+  paid: "bg-emerald-100 text-emerald-700",
+};
+
+function FnFTab({
+  fnf,
+  exitId,
+  onReload,
+  onExitChanged,
+}: {
+  fnf: any;
+  exitId: string;
+  onReload: () => void;
+  onExitChanged: () => void;
+}) {
+  const [actionLoading, setActionLoading] = useState(false);
+  const [basicSalaryDue, setBasicSalaryDue] = useState(0);
+  const [leaveEncashment, setLeaveEncashment] = useState(0);
+  const [gratuity, setGratuity] = useState(0);
+  const [bonusDue, setBonusDue] = useState(0);
+  const [otherEarnings, setOtherEarnings] = useState(0);
+  const [noticePayRecovery, setNoticePayRecovery] = useState(0);
+  const [otherDeductions, setOtherDeductions] = useState(0);
+  const [remarks, setRemarks] = useState("");
+  const [showPay, setShowPay] = useState(false);
+  const [payRef, setPayRef] = useState("");
+  const [pendingAction, setPendingAction] = useState<null | "recalculate" | "approve">(null);
+
+  // The parent owns the fetch; seed the editable fields whenever fnf changes.
+  useEffect(() => {
+    if (!fnf) return;
+    setBasicSalaryDue(fnf.basic_salary_due ?? 0);
+    setLeaveEncashment(fnf.leave_encashment ?? 0);
+    setGratuity(fnf.gratuity ?? 0);
+    setBonusDue(fnf.bonus_due ?? 0);
+    setOtherEarnings(fnf.other_earnings ?? 0);
+    setNoticePayRecovery(fnf.notice_pay_recovery ?? 0);
+    setOtherDeductions(fnf.other_deductions ?? 0);
+    setRemarks(fnf.remarks || "");
+  }, [fnf]);
+
+  const isPaid = fnf?.status === "paid";
+  const isEditable = !isPaid;
+  const totalEarnings = basicSalaryDue + leaveEncashment + gratuity + bonusDue + otherEarnings;
+  const totalDeductions = noticePayRecovery + otherDeductions;
+  const netPayable = totalEarnings - totalDeductions;
+
+  async function handleCalculate() {
+    setActionLoading(true);
+    try {
+      await apiPost(`/fnf/exit/${exitId}/calculate`);
+      onReload();
+      setPendingAction(null);
+      toast.success("FnF calculated");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to calculate FnF");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleSave() {
+    setActionLoading(true);
+    try {
+      await apiPut(`/fnf/exit/${exitId}`, {
+        basic_salary_due: basicSalaryDue,
+        leave_encashment: leaveEncashment,
+        gratuity,
+        bonus_due: bonusDue,
+        other_earnings: otherEarnings,
+        notice_pay_recovery: noticePayRecovery,
+        other_deductions: otherDeductions,
+        remarks: remarks || undefined,
+      });
+      onReload();
+      toast.success("FnF updated");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to save FnF");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleApprove() {
+    setActionLoading(true);
+    try {
+      await apiPost(`/fnf/exit/${exitId}/approve`);
+      onReload();
+      setPendingAction(null);
+      toast.success("FnF approved");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to approve FnF");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleMarkPaid() {
+    if (!payRef.trim()) return;
+    setActionLoading(true);
+    try {
+      await apiPost(`/fnf/exit/${exitId}/mark-paid`, { payment_reference: payRef.trim() });
+      setShowPay(false);
+      setPayRef("");
+      onReload();
+      onExitChanged(); // mark-paid flips the parent exit to fnf_processed
+      toast.success("FnF marked as paid");
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || err?.message || "Failed to mark as paid");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  const AmountField = ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: number;
+    onChange: (v: number) => void;
+  }) => (
+    <div className="flex items-center justify-between border-b border-gray-100 py-2.5 last:border-0">
+      <span className="text-sm text-gray-700">{label}</span>
+      <div className="flex items-center gap-1">
+        <span className="text-xs text-gray-400">INR</span>
+        <input
+          type="number"
+          value={value / 100}
+          onChange={(e) => onChange(Math.round(parseFloat(e.target.value || "0") * 100))}
+          disabled={!isEditable}
+          step="0.01"
+          className="w-32 rounded border border-gray-300 px-2 py-1 text-right text-sm font-mono focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500 disabled:bg-gray-50 disabled:text-gray-500"
+        />
+      </div>
+    </div>
+  );
+
+  // Empty state — no FnF calculated yet.
+  if (!fnf) {
+    return (
+      <div className="py-8 text-center">
+        <Calculator className="mx-auto mb-3 h-10 w-10 text-gray-300" />
+        <p className="mb-4 text-sm text-gray-500">No full &amp; final settlement yet.</p>
+        <button
+          onClick={handleCalculate}
+          disabled={actionLoading}
+          className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+        >
+          {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+          Calculate Settlement
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Header + status */}
+      <div className="flex items-center gap-3">
+        <Calculator className="h-5 w-5 text-rose-500" />
+        <h3 className="text-sm font-semibold text-gray-900">Full &amp; Final Settlement</h3>
+        <span
+          className={cn(
+            "inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize",
+            FNF_STATUS_COLORS[fnf.status] || "bg-gray-100 text-gray-600",
+          )}
+        >
+          {fnf.status}
+        </span>
+      </div>
+
+      {isPaid && fnf.paid_date && (
+        <div className="flex items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+          <Banknote className="h-5 w-5 text-emerald-600" />
+          <div>
+            <p className="text-sm font-medium text-emerald-800">Payment Completed</p>
+            <p className="text-xs text-emerald-600">Paid on {formatDate(fnf.paid_date)}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Earnings / Deductions */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-gray-200 p-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-emerald-600">Earnings</h4>
+          <AmountField label="Pending Salary (pro-rata)" value={basicSalaryDue} onChange={setBasicSalaryDue} />
+          <AmountField label="Leave Encashment" value={leaveEncashment} onChange={setLeaveEncashment} />
+          <AmountField label="Gratuity" value={gratuity} onChange={setGratuity} />
+          <AmountField label="Bonus" value={bonusDue} onChange={setBonusDue} />
+          <AmountField label="Other Earnings" value={otherEarnings} onChange={setOtherEarnings} />
+          <div className="mt-2 flex items-center justify-between border-t border-gray-200 pt-2 text-sm font-semibold text-emerald-700">
+            <span>Total Earnings</span><span>{formatINR(totalEarnings)}</span>
+          </div>
+        </div>
+        <div className="rounded-lg border border-gray-200 p-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-red-600">Deductions</h4>
+          <AmountField label="Notice Period Recovery" value={noticePayRecovery} onChange={setNoticePayRecovery} />
+          <AmountField label="Other Deductions" value={otherDeductions} onChange={setOtherDeductions} />
+          <div className="mt-2 flex items-center justify-between border-t border-gray-200 pt-2 text-sm font-semibold text-red-700">
+            <span>Total Deductions</span><span>{formatINR(totalDeductions)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Net payable */}
+      <div
+        className={cn(
+          "flex items-center justify-between rounded-lg p-4",
+          netPayable >= 0 ? "bg-emerald-50 text-emerald-800" : "bg-red-50 text-red-800",
+        )}
+      >
+        <span className="text-sm font-semibold">Net Payable</span>
+        <span className="text-lg font-bold">{formatINR(netPayable)}</span>
+      </div>
+
+      {/* Remarks */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-600">Remarks</label>
+        <textarea
+          value={remarks}
+          onChange={(e) => setRemarks(e.target.value)}
+          disabled={!isEditable}
+          rows={2}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none disabled:bg-gray-50"
+        />
+      </div>
+
+      {isEditable && (
+        <p className="text-xs text-gray-400">
+          Auto-calculation seeds amounts from notice/tenure only — enter the actual salary-based amounts above and Save.
+        </p>
+      )}
+
+      {/* Mark-paid inline input */}
+      {showPay && (
+        <div className="flex flex-wrap items-end gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <div className="flex-1 min-w-[200px]">
+            <label className="mb-1 block text-xs font-medium text-gray-600">Payment reference</label>
+            <input
+              value={payRef}
+              onChange={(e) => setPayRef(e.target.value)}
+              placeholder="e.g. NEFT-FNF-2026-0042"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <button
+            onClick={handleMarkPaid}
+            disabled={!payRef.trim() || actionLoading}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+            Confirm Payment
+          </button>
+          <button
+            onClick={() => { setShowPay(false); setPayRef(""); }}
+            disabled={actionLoading}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Status-driven actions */}
+      {!isPaid && !showPay && (
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gray-100 pt-4">
+          {isEditable && fnf.status !== "approved" && (
+            <button
+              onClick={() => setPendingAction("recalculate")}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              <RefreshCw className="h-4 w-4" /> Recalculate
+            </button>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={actionLoading}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+          >
+            {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />} Save Changes
+          </button>
+          {fnf.status === "calculated" && (
+            <button
+              onClick={() => setPendingAction("approve")}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+            >
+              <CheckCircle className="h-4 w-4" /> Approve
+            </button>
+          )}
+          {fnf.status === "approved" && (
+            <button
+              onClick={() => setShowPay(true)}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              <Banknote className="h-4 w-4" /> Mark Paid
+            </button>
+          )}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={pendingAction !== null}
+        title={pendingAction === "approve" ? "Approve FnF settlement?" : "Recalculate FnF?"}
+        message={
+          pendingAction === "approve"
+            ? "Approving locks the settlement from recalculation. Continue?"
+            : "Recalculating overwrites any manual amount edits with auto-derived values. Continue?"
+        }
+        confirmLabel={pendingAction === "approve" ? "Approve" : "Recalculate"}
+        tone="primary"
+        loading={actionLoading}
+        onConfirm={() => { if (pendingAction === "approve") handleApprove(); else handleCalculate(); }}
+        onCancel={() => setPendingAction(null)}
+      />
+    </div>
+  );
 }
 
 const LETTER_TYPES: Record<string, string> = {

--- a/packages/client/src/pages/letters/LetterTemplatesPage.tsx
+++ b/packages/client/src/pages/letters/LetterTemplatesPage.tsx
@@ -7,10 +7,12 @@ import {
   Loader2,
   X,
   Code,
+  Trash2,
 } from "lucide-react";
-import { apiGet, apiPost, apiPut } from "@/api/client";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/api/client";
 import toast from "react-hot-toast";
 import { cn } from "@/lib/utils";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 const LETTER_TYPES = [
   { key: "experience", label: "Experience Letter" },
@@ -42,6 +44,8 @@ export function LetterTemplatesPage() {
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<any>(null);
   const [preview, setPreview] = useState<any>(null);
+  const [deleteTarget, setDeleteTarget] = useState<any>(null);
+  const [deleting, setDeleting] = useState(false);
   const [form, setForm] = useState({
     letter_type: "experience",
     name: "",
@@ -75,6 +79,21 @@ export function LetterTemplatesPage() {
       is_default: t.is_default,
     });
     setShowForm(true);
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await apiDelete(`/letters/templates/${deleteTarget.id}`);
+      toast.success("Template deleted");
+      setDeleteTarget(null);
+      await fetchTemplates();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error?.message || "Failed to delete template");
+    } finally {
+      setDeleting(false);
+    }
   }
 
   function openNew() {
@@ -268,11 +287,29 @@ export function LetterTemplatesPage() {
                   <Edit3 className="h-3 w-3" />
                   Edit
                 </button>
+                <button
+                  onClick={() => setDeleteTarget(t)}
+                  className="inline-flex items-center gap-1 rounded bg-red-50 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-100"
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Delete
+                </button>
               </div>
             </div>
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete letter template?"
+        message={`"${deleteTarget?.name ?? ""}" will be removed and can no longer be used to generate letters.`}
+        confirmLabel="Delete"
+        tone="danger"
+        loading={deleting}
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/packages/client/src/pages/settings/SettingsPage.tsx
+++ b/packages/client/src/pages/settings/SettingsPage.tsx
@@ -1,33 +1,136 @@
 import { useState, useEffect } from "react";
-import { Settings, Loader2, Save } from "lucide-react";
+import {
+  Settings as SettingsIcon,
+  Loader2,
+  Save,
+  Clock,
+  ShieldCheck,
+  Mail,
+} from "lucide-react";
 import { apiGet, apiPut } from "@/api/client";
 import toast from "react-hot-toast";
 
+type FormState = {
+  default_notice_period_days: number;
+  auto_initiate_clearance: boolean;
+  require_exit_interview: boolean;
+  fnf_approval_required: boolean;
+  alumni_opt_in_default: boolean;
+  email_on_exit_initiated: boolean;
+  email_on_clearance_pending: boolean;
+  email_on_clearance_completed: boolean;
+  email_on_fnf_calculated: boolean;
+  email_on_fnf_approved: boolean;
+  email_on_exit_completed: boolean;
+};
+
+const DEFAULTS: FormState = {
+  default_notice_period_days: 30,
+  auto_initiate_clearance: true,
+  require_exit_interview: true,
+  fnf_approval_required: true,
+  alumni_opt_in_default: true,
+  email_on_exit_initiated: true,
+  email_on_clearance_pending: true,
+  email_on_clearance_completed: true,
+  email_on_fnf_calculated: true,
+  email_on_fnf_approved: true,
+  email_on_exit_completed: true,
+};
+
+// ── Reusable toggle row ─────────────────────────────────────────────────────
+function Toggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-rose-400 focus:ring-offset-2 ${
+        checked ? "bg-rose-600" : "bg-gray-300"
+      }`}
+    >
+      <span
+        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+          checked ? "translate-x-6" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}
+
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-3.5">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-900">{label}</p>
+        <p className="mt-0.5 text-xs leading-relaxed text-gray-500">{description}</p>
+      </div>
+      <Toggle checked={checked} onChange={onChange} />
+    </div>
+  );
+}
+
+// Card with a coloured icon header.
+function SettingsCard({
+  icon,
+  title,
+  subtitle,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div className="flex items-center gap-3 border-b border-gray-100 px-6 py-4">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-rose-50 text-rose-600">
+          {icon}
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+          <p className="text-xs text-gray-500">{subtitle}</p>
+        </div>
+      </div>
+      <div className="px-6 py-2">{children}</div>
+    </div>
+  );
+}
+
 export function SettingsPage() {
-  const [settings, setSettings] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [form, setForm] = useState({
-    default_notice_period_days: 30,
-    auto_initiate_clearance: true,
-    require_exit_interview: true,
-    fnf_approval_required: true,
-    alumni_opt_in_default: true,
-    email_on_exit_initiated: true,
-    email_on_clearance_pending: true,
-    email_on_clearance_completed: true,
-    email_on_fnf_calculated: true,
-    email_on_fnf_approved: true,
-    email_on_exit_completed: true,
-  });
+  const [form, setForm] = useState<FormState>(DEFAULTS);
+  const [saved, setSaved] = useState<FormState>(DEFAULTS); // last-persisted snapshot
+
+  const dirty = JSON.stringify(form) !== JSON.stringify(saved);
+
+  const set = (patch: Partial<FormState>) => setForm((f) => ({ ...f, ...patch }));
 
   async function fetchSettings() {
     setLoading(true);
     try {
       const res = await apiGet<any>("/settings");
       if (res.success && res.data) {
-        setSettings(res.data);
-        setForm({
+        const next: FormState = {
           default_notice_period_days: res.data.default_notice_period_days ?? 30,
           auto_initiate_clearance: Boolean(res.data.auto_initiate_clearance),
           require_exit_interview: Boolean(res.data.require_exit_interview),
@@ -39,7 +142,9 @@ export function SettingsPage() {
           email_on_fnf_calculated: res.data.email_on_fnf_calculated !== false,
           email_on_fnf_approved: res.data.email_on_fnf_approved !== false,
           email_on_exit_completed: res.data.email_on_exit_completed !== false,
-        });
+        };
+        setForm(next);
+        setSaved(next);
       }
     } catch {
       toast.error("Failed to load settings");
@@ -58,7 +163,7 @@ export function SettingsPage() {
     try {
       const res = await apiPut<any>("/settings", form);
       if (res.success) {
-        setSettings(res.data);
+        setSaved(form);
         toast.success("Settings saved");
       }
     } catch (err: any) {
@@ -77,286 +182,139 @@ export function SettingsPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">Exit Settings</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          Configure notice periods, clearance, FnF, and alumni defaults.
-        </p>
+    <form onSubmit={handleSave} className="mx-auto max-w-3xl space-y-6 pb-24">
+      {/* Page header */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-rose-600 text-white">
+          <SettingsIcon className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Exit Settings</h1>
+          <p className="text-sm text-gray-500">
+            Configure notice periods, clearance, FnF, and alumni defaults.
+          </p>
+        </div>
       </div>
 
-      <form onSubmit={handleSave} className="rounded-lg border border-gray-200 bg-white p-6 space-y-6">
-        {/* Notice Period */}
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            Default Notice Period (days)
-          </label>
-          <p className="mt-0.5 text-xs text-gray-500">
-            Applied when initiating an exit if no custom period is specified.
-          </p>
-          <input
-            type="number"
-            min={0}
-            max={365}
-            value={form.default_notice_period_days}
-            onChange={(e) => setForm({ ...form, default_notice_period_days: Number(e.target.value) })}
-            className="mt-2 block w-32 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+      {/* General */}
+      <SettingsCard
+        icon={<ShieldCheck className="h-5 w-5" />}
+        title="General"
+        subtitle="Defaults applied across the exit workflow."
+      >
+        <div className="flex items-start justify-between gap-4 py-3.5">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-gray-900">Default Notice Period</p>
+            <p className="mt-0.5 text-xs leading-relaxed text-gray-500">
+              Applied when initiating an exit if no custom period is specified.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <Clock className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <input
+                type="number"
+                min={0}
+                max={365}
+                value={form.default_notice_period_days}
+                onChange={(e) => set({ default_notice_period_days: Number(e.target.value) })}
+                className="w-28 rounded-lg border border-gray-300 py-2 pl-8 pr-3 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+              />
+            </div>
+            <span className="text-xs text-gray-400">days</span>
+          </div>
+        </div>
+
+        <div className="divide-y divide-gray-100">
+          <ToggleRow
+            label="Auto-Initiate Clearance"
+            description="Automatically create clearance records when an exit moves to clearance stage."
+            checked={form.auto_initiate_clearance}
+            onChange={(v) => set({ auto_initiate_clearance: v })}
+          />
+          <ToggleRow
+            label="Require Exit Interview"
+            description="Exit interview must be completed before exit can be finalized."
+            checked={form.require_exit_interview}
+            onChange={(v) => set({ require_exit_interview: v })}
+          />
+          <ToggleRow
+            label="FnF Approval Required"
+            description="Full & Final settlement requires HR admin approval before processing."
+            checked={form.fnf_approval_required}
+            onChange={(v) => set({ fnf_approval_required: v })}
+          />
+          <ToggleRow
+            label="Alumni Opt-In Default"
+            description="Automatically opt employees into the alumni network upon exit completion."
+            checked={form.alumni_opt_in_default}
+            onChange={(v) => set({ alumni_opt_in_default: v })}
           />
         </div>
+      </SettingsCard>
 
-        <hr className="border-gray-100" />
+      {/* Email notifications */}
+      <SettingsCard
+        icon={<Mail className="h-5 w-5" />}
+        title="Email Notifications"
+        subtitle="Enable or disable email notifications for each exit stage."
+      >
+        <div className="divide-y divide-gray-100">
+          <ToggleRow
+            label="Exit Initiated"
+            description="Notify employee, manager, and HR when an exit is initiated."
+            checked={form.email_on_exit_initiated}
+            onChange={(v) => set({ email_on_exit_initiated: v })}
+          />
+          <ToggleRow
+            label="Clearance Pending"
+            description="Notify department heads when clearance is required."
+            checked={form.email_on_clearance_pending}
+            onChange={(v) => set({ email_on_clearance_pending: v })}
+          />
+          <ToggleRow
+            label="Clearance Completed"
+            description="Notify employee when all clearances are completed."
+            checked={form.email_on_clearance_completed}
+            onChange={(v) => set({ email_on_clearance_completed: v })}
+          />
+          <ToggleRow
+            label="F&F Calculated"
+            description="Notify employee when F&F settlement is calculated."
+            checked={form.email_on_fnf_calculated}
+            onChange={(v) => set({ email_on_fnf_calculated: v })}
+          />
+          <ToggleRow
+            label="F&F Approved"
+            description="Notify employee when F&F settlement is approved."
+            checked={form.email_on_fnf_approved}
+            onChange={(v) => set({ email_on_fnf_approved: v })}
+          />
+          <ToggleRow
+            label="Exit Completed"
+            description="Notify employee when the exit process is complete."
+            checked={form.email_on_exit_completed}
+            onChange={(v) => set({ email_on_exit_completed: v })}
+          />
+        </div>
+      </SettingsCard>
 
-        {/* Toggle: Auto-initiate clearance */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">Auto-Initiate Clearance</label>
-            <p className="text-xs text-gray-500">
-              Automatically create clearance records when an exit moves to clearance stage.
-            </p>
-          </div>
+      {/* Sticky save bar */}
+      <div className="fixed inset-x-0 bottom-0 z-20 border-t border-gray-200 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3 sm:px-6">
+          <span className="text-xs text-gray-500">
+            {dirty ? "You have unsaved changes." : "All changes saved."}
+          </span>
           <button
-            type="button"
-            onClick={() => setForm({ ...form, auto_initiate_clearance: !form.auto_initiate_clearance })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.auto_initiate_clearance ? "bg-rose-600" : "bg-gray-300"
-            }`}
+            type="submit"
+            disabled={saving || !dirty}
+            className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.auto_initiate_clearance ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            {saving ? "Saving…" : "Save Settings"}
           </button>
         </div>
-
-        {/* Toggle: Require exit interview */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">Require Exit Interview</label>
-            <p className="text-xs text-gray-500">
-              Exit interview must be completed before exit can be finalized.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, require_exit_interview: !form.require_exit_interview })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.require_exit_interview ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.require_exit_interview ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Toggle: FnF approval required */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">FnF Approval Required</label>
-            <p className="text-xs text-gray-500">
-              Full & Final settlement requires HR admin approval before processing.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, fnf_approval_required: !form.fnf_approval_required })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.fnf_approval_required ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.fnf_approval_required ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Toggle: Alumni opt-in default */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">Alumni Opt-In Default</label>
-            <p className="text-xs text-gray-500">
-              Automatically opt employees into the alumni network upon exit completion.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, alumni_opt_in_default: !form.alumni_opt_in_default })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.alumni_opt_in_default ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.alumni_opt_in_default ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        <hr className="border-gray-100" />
-
-        {/* Email Notifications Section */}
-        <div>
-          <h3 className="text-base font-semibold text-gray-900 mb-1">Email Notifications</h3>
-          <p className="text-xs text-gray-500 mb-4">
-            Enable or disable email notifications for each exit stage.
-          </p>
-        </div>
-
-        {/* Toggle: Email on exit initiated */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">Exit Initiated</label>
-            <p className="text-xs text-gray-500">
-              Notify employee, manager, and HR when an exit is initiated.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, email_on_exit_initiated: !form.email_on_exit_initiated })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.email_on_exit_initiated ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.email_on_exit_initiated ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Toggle: Email on clearance pending */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">Clearance Pending</label>
-            <p className="text-xs text-gray-500">
-              Notify department heads when clearance is required.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, email_on_clearance_pending: !form.email_on_clearance_pending })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.email_on_clearance_pending ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.email_on_clearance_pending ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Toggle: Email on clearance completed */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">Clearance Completed</label>
-            <p className="text-xs text-gray-500">
-              Notify employee when all clearances are completed.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, email_on_clearance_completed: !form.email_on_clearance_completed })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.email_on_clearance_completed ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.email_on_clearance_completed ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Toggle: Email on FnF calculated */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">F&F Calculated</label>
-            <p className="text-xs text-gray-500">
-              Notify employee when F&F settlement is calculated.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, email_on_fnf_calculated: !form.email_on_fnf_calculated })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.email_on_fnf_calculated ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.email_on_fnf_calculated ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Toggle: Email on FnF approved */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">F&F Approved</label>
-            <p className="text-xs text-gray-500">
-              Notify employee when F&F settlement is approved.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, email_on_fnf_approved: !form.email_on_fnf_approved })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.email_on_fnf_approved ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.email_on_fnf_approved ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Toggle: Email on exit completed */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="text-sm font-medium text-gray-900">Exit Completed</label>
-            <p className="text-xs text-gray-500">
-              Notify employee when the exit process is complete.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setForm({ ...form, email_on_exit_completed: !form.email_on_exit_completed })}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              form.email_on_exit_completed ? "bg-rose-600" : "bg-gray-300"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                form.email_on_exit_completed ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </div>
-
-        <hr className="border-gray-100" />
-
-        <button
-          type="submit"
-          disabled={saving}
-          className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
-        >
-          <Save className="h-4 w-4" />
-          {saving ? "Saving..." : "Save Settings"}
-        </button>
-      </form>
-    </div>
+      </div>
+    </form>
   );
 }

--- a/packages/server/src/api/routes/letter.routes.ts
+++ b/packages/server/src/api/routes/letter.routes.ts
@@ -68,6 +68,21 @@ router.put(
   },
 );
 
+// DELETE /letters/templates/:id — soft-delete (sets is_active = false)
+router.delete(
+  "/templates/:id",
+  authorize("hr_admin", "hr_manager", "super_admin", "org_admin"),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      const result = await letterService.deleteTemplate(orgId, req.params.id as string);
+      return sendSuccess(res, result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // ---- Generation ----
 
 // POST /letters/exit/:exitId/generate


### PR DESCRIPTION
## Summary

Redesigns the Exit Settings page for clarity and polish. Frontend-only, with the exact same behavior, form fields, and API calls (GET/PUT /settings).

## Changes (SettingsPage.tsx)

- Group settings into two clearly-labelled cards (General, Email Notifications), each with a coloured icon header, instead of one long flat card.
- Extract reusable Toggle / ToggleRow / SettingsCard components, removing about 11 copy-pasted blocks of toggle markup (net fewer lines despite more functionality).
- Icon-led page header; the notice-period input gets a clock icon and a "days" suffix.
- Sticky bottom save bar with an "unsaved changes / all changes saved" indicator. Save is disabled until the form is actually dirty and shows a spinner while saving.
- Toggles are now keyboard-accessible (role=switch, aria-checked, focus ring).

## Verification

- tsc --noEmit passes (no type errors).
- HMR compiled cleanly; load/save behavior unchanged (same state shape and /settings endpoint).

## Note

Standalone UI refactor - touches only SettingsPage.tsx, independent of the exit-detail tab PRs. Branched off the latest stack branch so it merges cleanly after them; can rebase onto main if preferred.