### PR TITLE
feat(exit): employee self-service experience + admin page fixes

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
-import { isLoggedIn, useAuthStore, extractSSOToken } from "@/lib/auth-store";
+import { isLoggedIn, useAuthStore, extractSSOToken, homeFor } from "@/lib/auth-store";
 import { apiPost } from "@/api/client";
 import { AppRoutes } from "@/routes";
 
@@ -14,7 +14,8 @@ function PageLoader() {
 }
 
 function AuthRedirect() {
-  return isLoggedIn() ? <Navigate to="/dashboard" replace /> : <Navigate to="/login" replace />;
+  // Send admins to the management dashboard, employees to their self-service hub.
+  return isLoggedIn() ? <Navigate to={homeFor()} replace /> : <Navigate to="/login" replace />;
 }
 
 function SSOGate({ children }: { children: React.ReactNode }) {
@@ -52,7 +53,7 @@ function SSOGate({ children }: { children: React.ReactNode }) {
         login(user, tokens);
 
         if (window.location.pathname === "/" || window.location.pathname === "/login") {
-          window.location.replace("/dashboard");
+          window.location.replace(homeFor(user));
           return;
         }
         setReady(true);

--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -19,39 +19,45 @@ import {
   Menu,
   X,
   UserPlus,
+  UserMinus,
 } from "lucide-react";
-import { isLoggedIn, getUser, useAuthStore } from "@/lib/auth-store";
+import { isLoggedIn, getUser, useAuthStore, isAdmin } from "@/lib/auth-store";
 import { cn, getInitials } from "@/lib/utils";
 import { BackToDashboard } from "@/components/BackToDashboard";
-
-type Role = "org_admin" | "hr_admin" | "hr_manager" | "employee";
 
 interface NavItem {
   to: string;
   label: string;
   icon: any;
-  adminOnly?: boolean; // if true, hidden from employee role
 }
 
-const NAV_ITEMS: NavItem[] = [
+// Full management console — shown to admin / HR roles.
+const ADMIN_NAV: NavItem[] = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { to: "/exits", label: "Exits", icon: DoorOpen, adminOnly: true },
+  { to: "/exits", label: "Exits", icon: DoorOpen },
   { to: "/checklists", label: "Checklists", icon: ClipboardCheck },
   { to: "/clearance", label: "Clearance", icon: ShieldCheck },
   { to: "/interviews", label: "Interviews", icon: MessageSquare },
-  { to: "/fnf", label: "FnF", icon: Calculator, adminOnly: true },
+  { to: "/fnf", label: "FnF", icon: Calculator },
   { to: "/buyout", label: "Notice Buyout", icon: DollarSign },
   { to: "/assets", label: "Assets", icon: Package },
   { to: "/kt", label: "KT", icon: BookOpen },
   { to: "/letters", label: "Letters", icon: FileSignature },
   { to: "/alumni", label: "Alumni", icon: GraduationCap },
-  { to: "/rehire", label: "Rehire", icon: UserPlus, adminOnly: true },
-  { to: "/analytics", label: "Analytics", icon: BarChart3, adminOnly: true },
-  { to: "/analytics/flight-risk", label: "Flight Risk", icon: AlertTriangle, adminOnly: true },
-  { to: "/settings", label: "Settings", icon: Settings, adminOnly: true },
+  { to: "/rehire", label: "Rehire", icon: UserPlus },
+  { to: "/analytics", label: "Analytics", icon: BarChart3 },
+  { to: "/analytics/flight-risk", label: "Flight Risk", icon: AlertTriangle },
+  { to: "/settings", label: "Settings", icon: Settings },
 ];
 
-const ADMIN_ROLES: Role[] = ["org_admin", "hr_admin", "hr_manager"];
+// Self-service hub — shown to the employee role. Every link points at a
+// "my own" page; no org-wide management views.
+const EMPLOYEE_NAV: NavItem[] = [
+  { to: "/exits/my", label: "My Exit", icon: UserMinus },
+  { to: "/interviews/my", label: "My Interview", icon: MessageSquare },
+  { to: "/kt/my", label: "My KT", icon: BookOpen },
+  { to: "/alumni/my", label: "Alumni", icon: GraduationCap },
+];
 
 export function DashboardLayout() {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -65,12 +71,15 @@ export function DashboardLayout() {
 
   if (!isLoggedIn()) return <Navigate to="/login" replace />;
   const displayName = user ? `${user.firstName} ${user.lastName}` : "User";
-  const roleLabel =
-    user?.role === "hr_admin"
-      ? "HR Admin"
-      : user?.role === "hr_manager"
-        ? "HR Manager"
-        : "Employee";
+  const ROLE_LABELS: Record<string, string> = {
+    super_admin: "Super Admin",
+    org_admin: "Org Admin",
+    hr_admin: "HR Admin",
+    hr_manager: "HR Manager",
+    employee: "Employee",
+  };
+  const roleLabel = ROLE_LABELS[user?.role || "employee"] || "Employee";
+  const navItems = isAdmin(user) ? ADMIN_NAV : EMPLOYEE_NAV;
 
   function SidebarContent() {
     return (
@@ -85,10 +94,7 @@ export function DashboardLayout() {
 
         {/* Nav */}
         <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-1">
-          {NAV_ITEMS.filter((item) => {
-            if (item.adminOnly && !ADMIN_ROLES.includes((user?.role || "employee") as Role)) return false;
-            return true;
-          }).map((item) => (
+          {navItems.map((item) => (
             <NavLink
               key={item.to}
               to={item.to}

--- a/packages/client/src/lib/auth-store.ts
+++ b/packages/client/src/lib/auth-store.ts
@@ -108,3 +108,24 @@ export function getToken(): string | null {
 export function isLoggedIn(): boolean {
   return !!getToken();
 }
+
+// ── Role helpers ────────────────────────────────────────────────────────────
+// Admin roles get the full management console; "employee" gets self-service.
+const ADMIN_ROLES = ["super_admin", "org_admin", "hr_admin", "hr_manager"];
+
+export function isAdmin(user?: AuthUser | null): boolean {
+  const role = (user ?? getUser())?.role ?? "employee";
+  return ADMIN_ROLES.includes(role);
+}
+
+export function isEmployee(user?: AuthUser | null): boolean {
+  return !isAdmin(user);
+}
+
+// Where each role lands after login / when hitting a route they can't access.
+export const EMPLOYEE_HOME = "/exits/my";
+export const ADMIN_HOME = "/dashboard";
+
+export function homeFor(user?: AuthUser | null): string {
+  return isAdmin(user) ? ADMIN_HOME : EMPLOYEE_HOME;
+}

--- a/packages/client/src/pages/assets/AssetListPage.tsx
+++ b/packages/client/src/pages/assets/AssetListPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, Link } from "react-router-dom";
 import {
   Package,
   Plus,
@@ -35,17 +35,23 @@ export function AssetListPage() {
   const [searchParams] = useSearchParams();
   const exitId = searchParams.get("exitId") || "";
   const [assets, setAssets] = useState<any[]>([]);
+  const [allAssets, setAllAssets] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState({ asset_name: "", asset_tag: "", category: "laptop", replacement_cost: "" });
   const [submitting, setSubmitting] = useState(false);
 
   async function fetchAssets() {
-    if (!exitId) return;
     setLoading(true);
     try {
-      const res = await apiGet<any[]>(`/assets/exit/${exitId}`);
-      if (res.success) setAssets(res.data || []);
+      if (exitId) {
+        const res = await apiGet<any[]>(`/assets/exit/${exitId}`);
+        if (res.success) setAssets(res.data || []);
+      } else {
+        // No exit selected → show the org-wide asset list.
+        const res = await apiGet<any[]>("/assets");
+        if (res.success) setAllAssets(res.data || []);
+      }
     } catch {
       toast.error("Failed to load assets");
     } finally {
@@ -116,18 +122,77 @@ export function AssetListPage() {
         )}
       </div>
 
+      {/* Org-wide asset list (shown when no specific exit is selected) */}
       {!exitId && (
-        <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
-          <Package className="mx-auto h-10 w-10 text-gray-300 mb-3" />
-          <p className="text-sm font-medium text-gray-900">Open an exit to manage its assets</p>
-          <p className="mt-1 text-sm text-gray-500">
-            Asset returns are tracked per exit. Pick an exit from the{" "}
-            <a href="/exits" className="font-medium text-rose-600 hover:text-rose-700 underline">
-              Exits list
-            </a>
-            , then use the Assets tab on its detail page.
-          </p>
-        </div>
+        loading ? (
+          <div className="flex h-32 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-rose-600" />
+          </div>
+        ) : allAssets.length === 0 ? (
+          <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
+            <Package className="mx-auto h-10 w-10 text-gray-300 mb-3" />
+            <p className="text-sm font-medium text-gray-900">No assets tracked yet</p>
+            <p className="mt-1 text-sm text-gray-500">
+              Asset returns are tracked per exit. Open an exit from the{" "}
+              <a href="/exits" className="font-medium text-rose-600 hover:text-rose-700 underline">
+                Exits list
+              </a>{" "}
+              and add the assets to be returned.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white -mx-4 lg:mx-0">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Employee</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Asset</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Category</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Status</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {allAssets.map((asset: any) => {
+                  const sc = STATUS_CONFIG[asset.status] || STATUS_CONFIG.pending;
+                  const Icon = sc.icon;
+                  const name = asset.employee
+                    ? `${asset.employee.first_name} ${asset.employee.last_name}`
+                    : "—";
+                  return (
+                    <tr key={asset.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3">
+                        <p className="text-sm font-medium text-gray-900">{name}</p>
+                        {asset.employee?.designation && (
+                          <p className="text-xs text-gray-500">{asset.employee.designation}</p>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700">
+                        {asset.asset_name}
+                        {asset.asset_tag && <span className="ml-1 text-xs text-gray-400">({asset.asset_tag})</span>}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 capitalize">{asset.category?.replace("_", " ")}</td>
+                      <td className="px-4 py-3">
+                        <span className={cn("inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium", sc.color)}>
+                          <Icon className="h-3 w-3" />
+                          {sc.label}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <Link
+                          to={`/assets?exitId=${asset.exit_request_id}`}
+                          className="text-sm font-medium text-rose-600 hover:text-rose-700"
+                        >
+                          Manage
+                        </Link>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )
       )}
 
       {showForm && (

--- a/packages/client/src/pages/clearance/ClearanceRecordsPage.tsx
+++ b/packages/client/src/pages/clearance/ClearanceRecordsPage.tsx
@@ -21,6 +21,16 @@ interface MyClearance {
   remarks: string | null;
   pending_amount: number;
   department?: { id: string; name: string } | null;
+  employee?: { first_name: string; last_name: string; designation: string | null } | null;
+}
+
+// pending_amount is stored in paise.
+function formatINR(paise: number): string {
+  return new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: "INR",
+    maximumFractionDigits: 0,
+  }).format((paise || 0) / 100);
 }
 
 export function ClearanceRecordsPage() {
@@ -84,7 +94,7 @@ export function ClearanceRecordsPage() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Clearance Records</h1>
           <p className="mt-1 text-sm text-gray-500">
-            Pending clearance approvals assigned to you.
+            Pending department clearance approvals across all exits.
           </p>
         </div>
         <Link
@@ -99,7 +109,7 @@ export function ClearanceRecordsPage() {
       {clearances.length === 0 ? (
         <div className="rounded-xl border border-gray-200 bg-white p-12 text-center">
           <Shield className="mx-auto h-12 w-12 text-gray-300 mb-3" />
-          <p className="text-sm text-gray-500">No pending clearances assigned to you.</p>
+          <p className="text-sm text-gray-500">No pending clearances.</p>
         </div>
       ) : (
         <div className="rounded-xl border border-gray-200 bg-white overflow-x-auto -mx-4 lg:mx-0">
@@ -107,7 +117,7 @@ export function ClearanceRecordsPage() {
             <thead>
               <tr className="border-b border-gray-100 text-xs font-medium uppercase tracking-wider text-gray-500">
                 <th className="px-6 py-3">Department</th>
-                <th className="px-6 py-3">Exit Request</th>
+                <th className="px-6 py-3">Employee</th>
                 <th className="px-6 py-3">Status</th>
                 <th className="px-6 py-3">Pending Amount</th>
                 <th className="px-6 py-3 text-right">Actions</th>
@@ -122,10 +132,15 @@ export function ClearanceRecordsPage() {
                   <td className="px-6 py-4">
                     <Link
                       to={`/exits/${c.exit_request_id}`}
-                      className="text-rose-600 hover:text-rose-700 text-sm"
+                      className="text-sm font-medium text-gray-900 hover:text-rose-600"
                     >
-                      {c.exit_request_id.slice(0, 8)}...
+                      {c.employee
+                        ? `${c.employee.first_name} ${c.employee.last_name}`
+                        : "—"}
                     </Link>
+                    {c.employee?.designation && (
+                      <p className="text-xs text-gray-500">{c.employee.designation}</p>
+                    )}
                   </td>
                   <td className="px-6 py-4">
                     <span
@@ -138,7 +153,7 @@ export function ClearanceRecordsPage() {
                     </span>
                   </td>
                   <td className="px-6 py-4 text-gray-600">
-                    {c.pending_amount > 0 ? c.pending_amount : "--"}
+                    {c.pending_amount > 0 ? formatINR(c.pending_amount) : "--"}
                   </td>
                   <td className="px-6 py-4">
                     {c.status === "pending" && (

--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -64,18 +64,27 @@ export function DashboardPage() {
 
     async function load() {
       try {
-        // Fetch recent exits
-        const exitRes = await apiGet<any>("/exits", { perPage: 10 });
+        // Recent exits for the table (top 10) + a full fetch for accurate
+        // counts (computing stats from only 10 rows undercounts everything).
+        const [recentRes, allRes, clearanceRes] = await Promise.all([
+          apiGet<any>("/exits", { perPage: 10 }),
+          apiGet<any>("/exits", { perPage: 1000 }),
+          apiGet<any[]>("/clearance/my").catch(() => ({ data: [] as any[] })),
+        ]);
         if (cancelled) return;
 
-        const exits: ExitListItem[] = exitRes.data?.data ?? [];
-        setRecentExits(exits);
+        setRecentExits(recentRes.data?.data ?? []);
 
-        // Compute stats from the full list
+        const exits: ExitListItem[] = allRes.data?.data ?? [];
         const activeStatuses = ["initiated", "notice_period", "clearance_pending", "fnf_pending", "fnf_processed"];
         const activeExits = exits.filter((e) => activeStatuses.includes(e.status)).length;
-        const clearancePending = exits.filter((e) => e.status === "clearance_pending").length;
         const fnfPending = exits.filter((e) => e.status === "fnf_pending").length;
+
+        // Clearance Pending = distinct exits with at least one pending clearance
+        // record (matches the Clearance page, which lists clearance records — an
+        // exit's *status* may have moved on while clearances are still open).
+        const clearanceRecords: any[] = clearanceRes.data ?? [];
+        const clearancePending = new Set(clearanceRecords.map((c) => c.exit_request_id)).size;
 
         const now = new Date();
         const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();

--- a/packages/client/src/pages/exits/ExitListPage.tsx
+++ b/packages/client/src/pages/exits/ExitListPage.tsx
@@ -6,6 +6,7 @@ import { cn, formatDate } from "@/lib/utils";
 
 const STATUS_OPTIONS = [
   { value: "", label: "All Statuses" },
+  { value: "active", label: "Active (in progress)" },
   { value: "initiated", label: "Initiated" },
   { value: "notice_period", label: "Notice Period" },
   { value: "clearance_pending", label: "Clearance Pending" },

--- a/packages/client/src/pages/exits/MyExitPage.tsx
+++ b/packages/client/src/pages/exits/MyExitPage.tsx
@@ -8,9 +8,19 @@ import {
   CheckCircle,
   DollarSign,
   Calculator,
+  FileSignature,
+  Download,
 } from "lucide-react";
-import { apiGet } from "@/api/client";
+import { apiGet, api } from "@/api/client";
+import toast from "react-hot-toast";
 import { cn, formatDate } from "@/lib/utils";
+
+const LETTER_TYPES: Record<string, string> = {
+  experience: "Experience Letter",
+  relieving: "Relieving Letter",
+  service_certificate: "Service Certificate",
+  noc: "NOC",
+};
 
 const STATUS_COLORS: Record<string, string> = {
   initiated: "bg-blue-100 text-blue-700",
@@ -50,6 +60,8 @@ const CLEARANCE_STATUS_COLORS: Record<string, string> = {
 export function MyExitPage() {
   const [exit, setExit] = useState<any>(null);
   const [checklist, setChecklist] = useState<any>(null);
+  const [letters, setLetters] = useState<any[]>([]);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -70,6 +82,14 @@ export function MyExitPage() {
           } catch {
             // no checklist
           }
+
+          // Load my documents (generated letters)
+          try {
+            const lettersRes = await apiGet<any[]>("/self-service/my-letters");
+            if (!cancelled) setLetters(lettersRes.data ?? []);
+          } catch {
+            // no letters
+          }
         }
       } catch {
         // no exit
@@ -81,6 +101,29 @@ export function MyExitPage() {
     load();
     return () => { cancelled = true; };
   }, []);
+
+  // The download endpoint returns raw HTML as an attachment, so fetch it as a
+  // blob and trigger a browser download.
+  async function handleDownload(letterId: string, letterType: string) {
+    setDownloadingId(letterId);
+    try {
+      const response = await api.get(`/self-service/my-letters/${letterId}/download`, {
+        responseType: "blob",
+      });
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `${letterType}_letter.html`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch {
+      toast.error("Failed to download document");
+    } finally {
+      setDownloadingId(null);
+    }
+  }
 
   if (loading) {
     return (
@@ -287,6 +330,42 @@ export function MyExitPage() {
                 >
                   {item.status.replace(/_/g, " ")}
                 </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* My Documents */}
+      {letters.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white">
+          <div className="flex items-center gap-2 border-b border-gray-100 px-6 py-4">
+            <FileSignature className="h-5 w-5 text-rose-500" />
+            <h2 className="text-lg font-semibold text-gray-900">My Documents</h2>
+          </div>
+          <div className="divide-y divide-gray-50 px-6">
+            {letters.map((l) => (
+              <div key={l.id} className="flex items-center justify-between py-3">
+                <div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {LETTER_TYPES[l.letter_type] || l.letter_type}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Issued: {l.issued_date ? formatDate(l.issued_date) : "--"}
+                  </p>
+                </div>
+                <button
+                  onClick={() => handleDownload(l.id, l.letter_type)}
+                  disabled={downloadingId === l.id}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  {downloadingId === l.id ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Download className="h-3.5 w-3.5" />
+                  )}
+                  Download
+                </button>
               </div>
             ))}
           </div>

--- a/packages/client/src/pages/exits/ResignationPage.tsx
+++ b/packages/client/src/pages/exits/ResignationPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { UserMinus, Loader2 } from "lucide-react";
 import { apiPost } from "@/api/client";
+import { homeFor } from "@/lib/auth-store";
 
 const REASON_CATEGORIES = [
   { value: "better_opportunity", label: "Better Opportunity" },
@@ -162,7 +163,7 @@ export function ResignationPage() {
           </button>
           <button
             type="button"
-            onClick={() => navigate("/dashboard")}
+            onClick={() => navigate(homeFor())}
             className="rounded-lg border border-gray-300 px-5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
           >
             Cancel

--- a/packages/client/src/pages/fnf/FnFListPage.tsx
+++ b/packages/client/src/pages/fnf/FnFListPage.tsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import {
   Calculator,
   DollarSign,
-  Search,
+  Loader2,
   ArrowRight,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { apiGet } from "@/api/client";
+import { cn, formatDate } from "@/lib/utils";
 
 const STATUS_CONFIG: Record<string, { bg: string; label: string }> = {
   draft: { bg: "bg-gray-100 text-gray-600", label: "Draft" },
@@ -15,15 +16,64 @@ const STATUS_CONFIG: Record<string, { bg: string; label: string }> = {
   paid: { bg: "bg-emerald-100 text-emerald-700", label: "Paid" },
 };
 
+const STATUS_FILTERS = [
+  { value: "", label: "All Statuses" },
+  { value: "draft", label: "Draft" },
+  { value: "calculated", label: "Calculated" },
+  { value: "approved", label: "Approved" },
+  { value: "paid", label: "Paid" },
+];
+
+interface FnFRow {
+  id: string;
+  exit_request_id: string;
+  status: string;
+  total_payable: number;
+  updated_at: string;
+  last_working_date: string | null;
+  employee?: {
+    first_name: string;
+    last_name: string;
+    designation: string | null;
+    emp_code: string | null;
+  } | null;
+}
+
+// Amounts are stored in paise; show as ₹ with grouping.
+function formatINR(paise: number): string {
+  return new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: "INR",
+    maximumFractionDigits: 0,
+  }).format((paise || 0) / 100);
+}
+
 export function FnFListPage() {
   const navigate = useNavigate();
-  const [exitIdSearch, setExitIdSearch] = useState("");
+  const [rows, setRows] = useState<FnFRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState("");
 
-  const handleGoToFnF = () => {
-    if (exitIdSearch.trim()) {
-      navigate(`/fnf/${exitIdSearch.trim()}`);
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const params: Record<string, any> = {};
+        if (statusFilter) params.status = statusFilter;
+        const res = await apiGet<FnFRow[]>("/fnf", params);
+        if (!cancelled) setRows(res.data ?? []);
+      } catch {
+        if (!cancelled) setRows([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
-  };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [statusFilter]);
 
   return (
     <div className="space-y-6">
@@ -38,72 +88,129 @@ export function FnFListPage() {
         </p>
       </div>
 
-      {/* Quick lookup */}
-      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-        <h2 className="font-medium text-gray-900 mb-3">Look up FnF by Exit ID</h2>
-        <div className="flex gap-3">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-            <input
-              type="text"
-              value={exitIdSearch}
-              onChange={(e) => setExitIdSearch(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleGoToFnF()}
-              className="w-full rounded-lg border border-gray-300 pl-10 pr-4 py-2.5 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
-              placeholder="Enter exit request ID..."
-            />
-          </div>
-          <button
-            onClick={handleGoToFnF}
-            disabled={!exitIdSearch.trim()}
-            className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50 transition-colors"
-          >
-            View FnF
-            <ArrowRight className="h-4 w-4" />
-          </button>
-        </div>
+      {/* Filter */}
+      <div className="flex items-center gap-3">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+        >
+          {STATUS_FILTERS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <span className="text-sm text-gray-500">
+          {loading ? "Loading…" : `${rows.length} settlement${rows.length === 1 ? "" : "s"}`}
+        </span>
       </div>
 
-      {/* Info section */}
-      <div className="rounded-lg border border-gray-200 bg-white p-8">
-        <div className="text-center">
+      {/* List */}
+      {loading ? (
+        <div className="flex h-64 items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-rose-600" />
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-10 text-center">
           <DollarSign className="mx-auto h-12 w-12 text-gray-300" />
-          <h3 className="mt-4 text-sm font-medium text-gray-900">
-            FnF settlements are linked to exit requests
-          </h3>
-          <p className="mt-2 text-sm text-gray-500 max-w-lg mx-auto">
-            Navigate to an exit request to calculate, adjust, approve, and process the full and
-            final settlement. Each exit request has one FnF settlement record.
+          <h3 className="mt-4 text-sm font-medium text-gray-900">No FnF settlements yet</h3>
+          <p className="mt-2 mx-auto max-w-lg text-sm text-gray-500">
+            FnF settlements are created from an exit request. Open an exit and calculate its
+            full &amp; final settlement to see it here.
           </p>
           <button
             onClick={() => navigate("/exits")}
             className="mt-4 inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors"
           >
             View Exits
+            <ArrowRight className="h-4 w-4" />
           </button>
         </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Employee</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Last Working Date</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Net Payable</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                <th className="px-6 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.map((r) => {
+                const cfg = STATUS_CONFIG[r.status] || STATUS_CONFIG.draft;
+                const name = r.employee
+                  ? `${r.employee.first_name} ${r.employee.last_name}`
+                  : "—";
+                return (
+                  <tr key={r.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4">
+                      <Link
+                        to={`/fnf/${r.exit_request_id}`}
+                        className="text-sm font-medium text-gray-900 hover:text-rose-600"
+                      >
+                        {name}
+                      </Link>
+                      {r.employee?.designation && (
+                        <p className="text-xs text-gray-500">{r.employee.designation}</p>
+                      )}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-600">
+                      {r.last_working_date ? formatDate(r.last_working_date) : "—"}
+                    </td>
+                    <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                      {formatINR(r.total_payable)}
+                    </td>
+                    <td className="px-6 py-4">
+                      <span
+                        className={cn(
+                          "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
+                          cfg.bg,
+                        )}
+                      >
+                        {cfg.label}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-right">
+                      <Link
+                        to={`/fnf/${r.exit_request_id}`}
+                        className="inline-flex items-center gap-1 text-sm font-medium text-rose-600 hover:text-rose-700"
+                      >
+                        View
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
 
-        {/* FnF workflow */}
-        <div className="mt-8">
-          <h4 className="text-sm font-medium text-gray-700 text-center mb-4">Settlement Workflow</h4>
-          <div className="flex items-center justify-center gap-2">
-            {["draft", "calculated", "approved", "paid"].map((status, idx) => {
-              const cfg = STATUS_CONFIG[status];
-              return (
-                <div key={status} className="flex items-center gap-2">
-                  <span
-                    className={cn(
-                      "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
-                      cfg.bg,
-                    )}
-                  >
-                    {cfg.label}
-                  </span>
-                  {idx < 3 && <ArrowRight className="h-4 w-4 text-gray-300" />}
-                </div>
-              );
-            })}
-          </div>
+      {/* Workflow legend */}
+      <div className="rounded-lg border border-gray-200 bg-white p-5">
+        <h4 className="mb-4 text-center text-sm font-medium text-gray-700">Settlement Workflow</h4>
+        <div className="flex items-center justify-center gap-2">
+          {["draft", "calculated", "approved", "paid"].map((status, idx) => {
+            const cfg = STATUS_CONFIG[status];
+            return (
+              <div key={status} className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
+                    cfg.bg,
+                  )}
+                >
+                  {cfg.label}
+                </span>
+                {idx < 3 && <ArrowRight className="h-4 w-4 text-gray-300" />}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/packages/client/src/pages/interviews/MyExitInterviewPage.tsx
+++ b/packages/client/src/pages/interviews/MyExitInterviewPage.tsx
@@ -46,28 +46,25 @@ export function MyExitInterviewPage() {
 
   const fetchMyInterview = useCallback(async () => {
     try {
-      // Fetch self-service exit to find the user's active exit request
-      const exitRes = await apiGet<any>("/self-service/my-exit");
-      const myExit = exitRes.data;
-      if (!myExit?.id) {
+      // One self-service call resolves MY exit, my interview, and its template
+      // (with questions) — no exitId in the URL, no admin-only template fetch.
+      const res = await apiGet<{
+        interview: InterviewDetail | null;
+        template: TemplateWithQuestions | null;
+      }>("/self-service/my-interview");
+
+      const data = res.data?.interview ?? null;
+      if (!data) {
         setLoading(false);
         return;
       }
-      setExitId(myExit.id);
+      setExitId(data.exit_request_id);
+      setInterview(data);
+      setTemplate(res.data?.template ?? null);
 
-      // Fetch interview for this exit
-      const intRes = await apiGet<InterviewDetail>(`/interviews/exit/${myExit.id}`);
-      const data = intRes.data;
-      setInterview(data || null);
-
-      if (data?.template_id) {
-        const tRes = await apiGet<TemplateWithQuestions>(
-          `/interviews/templates/${data.template_id}`,
-        );
-        setTemplate(tRes.data || null);
-      }
-
-      // Pre-fill existing responses
+      // Pre-fill existing responses. If the employee has already answered, lock
+      // the form even if HR hasn't formally marked it completed yet, so a reload
+      // shows their submission instead of an editable blank form.
       if (data?.responses?.length) {
         const filled: Record<string, { text?: string; rating?: number }> = {};
         for (const r of data.responses) {
@@ -80,6 +77,7 @@ export function MyExitInterviewPage() {
         if (data.overall_rating) setOverallRating(data.overall_rating);
         if (data.summary?.includes("Would recommend: Yes")) setWouldRecommend(true);
         if (data.summary?.includes("Would recommend: No")) setWouldRecommend(false);
+        setSubmitted(true);
       }
     } catch {
       // No exit found — employee might not have an active exit
@@ -114,7 +112,7 @@ export function MyExitInterviewPage() {
         answer_rating: answers[q.id]?.rating || undefined,
       }));
 
-      await apiPost(`/interviews/exit/${exitId}/responses`, {
+      await apiPost("/self-service/my-interview/responses", {
         responses,
         overall_rating: overallRating || undefined,
         would_recommend: wouldRecommend,
@@ -243,29 +241,8 @@ export function MyExitInterviewPage() {
     );
   }
 
-  // No active exit
-  if (!exitId) {
-    return (
-      <div className="space-y-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-            <MessageSquare className="h-6 w-6 text-rose-600" />
-            My Exit Interview
-          </h1>
-          <p className="mt-1 text-sm text-gray-500">Submit your exit interview responses.</p>
-        </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-12 text-center">
-          <AlertCircle className="mx-auto h-12 w-12 text-gray-300" />
-          <h3 className="mt-4 text-sm font-medium text-gray-900">No active exit request</h3>
-          <p className="mt-1 text-sm text-gray-500">
-            You do not have an active exit request with a scheduled interview.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  // No interview scheduled
+  // No interview scheduled (covers both "no active exit" and "exit but no
+  // interview yet" — in both cases there is nothing for the employee to fill in)
   if (!interview) {
     return (
       <div className="space-y-6">

--- a/packages/client/src/pages/kt/MyKTPage.tsx
+++ b/packages/client/src/pages/kt/MyKTPage.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
 import {
   BookOpen,
-  Plus,
   CheckCircle2,
   Circle,
   FileText,
   Loader2,
   Clock,
+  CheckCircle,
 } from "lucide-react";
-import { apiGet, apiPost, apiPut } from "@/api/client";
+import { apiGet, apiPut } from "@/api/client";
 import toast from "react-hot-toast";
 import { cn, formatDate } from "@/lib/utils";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 const KT_STATUS: Record<string, { label: string; color: string }> = {
   not_started: { label: "Not Started", color: "bg-gray-100 text-gray-600" },
@@ -20,25 +20,19 @@ const KT_STATUS: Record<string, { label: string; color: string }> = {
 };
 
 export function MyKTPage() {
-  const [searchParams] = useSearchParams();
-  const exitId = searchParams.get("exitId") || "";
   const [kt, setKt] = useState<any>(null);
   const [loading, setLoading] = useState(true);
-  const [showForm, setShowForm] = useState(false);
-  const [form, setForm] = useState({ title: "", description: "", document_url: "" });
-  const [submitting, setSubmitting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [completing, setCompleting] = useState(false);
 
   async function fetchKT() {
-    if (!exitId) {
-      setLoading(false);
-      return;
-    }
     setLoading(true);
     try {
-      const res = await apiGet<any>(`/kt/exit/${exitId}`);
+      // Self-service: the server resolves MY exit — no exitId needed.
+      const res = await apiGet<any>("/self-service/my-kt");
       if (res.success) setKt(res.data);
     } catch {
-      // KT not found
+      // no KT plan
     } finally {
       setLoading(false);
     }
@@ -46,36 +40,36 @@ export function MyKTPage() {
 
   useEffect(() => {
     fetchKT();
-  }, [exitId]);
+  }, []);
 
-  async function handleAddItem(e: React.FormEvent) {
-    e.preventDefault();
-    setSubmitting(true);
-    try {
-      await apiPost(`/kt/exit/${exitId}/items`, {
-        title: form.title,
-        description: form.description || undefined,
-        document_url: form.document_url || undefined,
-      });
-      toast.success("KT item added");
-      setShowForm(false);
-      setForm({ title: "", description: "", document_url: "" });
-      fetchKT();
-    } catch (err: any) {
-      toast.error(err.response?.data?.error?.message || "Failed to add item");
-    } finally {
-      setSubmitting(false);
-    }
-  }
+  // Once the plan is completed the checklist is locked (read-only).
+  const planCompleted = kt?.status === "completed";
+  const items = kt?.items ?? [];
+  const allItemsDone = items.length > 0 && items.every((i: any) => i.status === "completed");
 
   async function toggleItem(itemId: string, currentStatus: string) {
+    if (planCompleted) return; // locked after completion
     const newStatus = currentStatus === "completed" ? "not_started" : "completed";
     try {
-      await apiPut(`/kt/items/${itemId}`, { status: newStatus });
+      await apiPut(`/self-service/my-kt/items/${itemId}`, { status: newStatus });
       toast.success(newStatus === "completed" ? "Item completed" : "Item reopened");
       fetchKT();
     } catch {
       toast.error("Failed to update item");
+    }
+  }
+
+  async function handleCompleteKT() {
+    setCompleting(true);
+    try {
+      await apiPut("/self-service/my-kt/complete", {});
+      toast.success("Knowledge transfer completed");
+      setConfirmOpen(false);
+      fetchKT();
+    } catch (err: any) {
+      toast.error(err.response?.data?.error?.message || "Failed to complete KT");
+    } finally {
+      setCompleting(false);
     }
   }
 
@@ -89,37 +83,22 @@ export function MyKTPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">My Knowledge Transfer</h1>
-          <p className="mt-1 text-sm text-gray-500">
-            View and manage your knowledge transfer items.
-          </p>
-        </div>
-        {kt && (
-          <button
-            onClick={() => setShowForm(!showForm)}
-            className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700"
-          >
-            <Plus className="h-4 w-4" />
-            Add Item
-          </button>
-        )}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">My Knowledge Transfer</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Track the knowledge transfer items assigned to you and mark them complete.
+        </p>
       </div>
 
-      {!exitId && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
-          No exit selected. Pass <code>?exitId=UUID</code> in the URL.
-        </div>
-      )}
-
-      {!kt && exitId ? (
+      {!kt ? (
         <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
           <BookOpen className="mx-auto h-10 w-10 text-gray-300 mb-3" />
-          <p className="text-gray-500">No KT plan found for your exit.</p>
-          <p className="mt-1 text-xs text-gray-400">Contact your HR team to set up a knowledge transfer plan.</p>
+          <p className="text-gray-500">No knowledge transfer has been assigned to you.</p>
+          <p className="mt-1 text-xs text-gray-400">
+            Your HR team will set up a KT plan if one is needed for your exit.
+          </p>
         </div>
-      ) : kt ? (
+      ) : (
         <>
           {/* KT info */}
           <div className="rounded-lg border border-gray-200 bg-white p-5">
@@ -140,64 +119,11 @@ export function MyKTPage() {
             </div>
           </div>
 
-          {/* Add item form */}
-          {showForm && (
-            <form onSubmit={handleAddItem} className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
-              <h3 className="text-lg font-semibold text-gray-900">Add KT Item</h3>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Title</label>
-                <input
-                  type="text"
-                  required
-                  value={form.title}
-                  onChange={(e) => setForm({ ...form, title: e.target.value })}
-                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
-                  placeholder="Handover deployment documentation"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Description</label>
-                <textarea
-                  value={form.description}
-                  onChange={(e) => setForm({ ...form, description: e.target.value })}
-                  rows={3}
-                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Document URL</label>
-                <input
-                  type="url"
-                  value={form.document_url}
-                  onChange={(e) => setForm({ ...form, document_url: e.target.value })}
-                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
-                  placeholder="https://docs.google.com/..."
-                />
-              </div>
-              <div className="flex gap-3">
-                <button
-                  type="submit"
-                  disabled={submitting}
-                  className="rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
-                >
-                  {submitting ? "Adding..." : "Add Item"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowForm(false)}
-                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                >
-                  Cancel
-                </button>
-              </div>
-            </form>
-          )}
-
           {/* Items */}
           <div className="space-y-2">
             {!kt.items || kt.items.length === 0 ? (
               <div className="rounded-lg border border-gray-200 bg-white p-6 text-center text-gray-500 text-sm">
-                No KT items yet.
+                No KT items have been assigned yet.
               </div>
             ) : (
               kt.items.map((item: any) => (
@@ -207,7 +133,8 @@ export function MyKTPage() {
                 >
                   <button
                     onClick={() => toggleItem(item.id, item.status)}
-                    className="mt-0.5 flex-shrink-0"
+                    disabled={planCompleted}
+                    className={cn("mt-0.5 flex-shrink-0", planCompleted && "cursor-default")}
                   >
                     {item.status === "completed" ? (
                       <CheckCircle2 className="h-5 w-5 text-green-600" />
@@ -238,8 +165,52 @@ export function MyKTPage() {
               ))
             )}
           </div>
+
+          {/* Complete-KT action / completed banner */}
+          {items.length > 0 && (
+            planCompleted ? (
+              <div className="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 p-4">
+                <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-600" />
+                <div>
+                  <p className="text-sm font-medium text-green-800">Knowledge transfer completed</p>
+                  <p className="text-xs text-green-700">
+                    {kt.completed_date
+                      ? `Completed on ${formatDate(kt.completed_date)}`
+                      : "All items handed over and signed off."}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-gray-600">
+                  {allItemsDone
+                    ? "All items are done. Finish your knowledge transfer to sign it off."
+                    : "Complete all the items above to finish your knowledge transfer."}
+                </p>
+                <button
+                  onClick={() => setConfirmOpen(true)}
+                  disabled={!allItemsDone}
+                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <CheckCircle className="h-4 w-4" />
+                  Mark KT as Complete
+                </button>
+              </div>
+            )
+          )}
         </>
-      ) : null}
+      )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Complete Knowledge Transfer?"
+        message="This marks your knowledge transfer as complete and locks the items. You won't be able to change them afterwards."
+        confirmLabel="Mark as Complete"
+        tone="primary"
+        loading={completing}
+        onConfirm={handleCompleteKT}
+        onCancel={() => setConfirmOpen(false)}
+      />
     </div>
   );
 }

--- a/packages/client/src/routes.tsx
+++ b/packages/client/src/routes.tsx
@@ -179,9 +179,11 @@ export function AppRoutes() {
         <Route path="/fnf" element={<AdminRoute><FnFListPage /></AdminRoute>} />
         <Route path="/fnf/:id" element={<AdminRoute><FnFDetailPage /></AdminRoute>} />
 
-        {/* Buyout */}
+        {/* Buyout — the list is admin-only, but the calculator is also the
+            employee's self-service "request a buyout" page (it defaults to
+            /self-service/my-buyout/*), so it must stay reachable by employees. */}
         <Route path="/buyout" element={<AdminRoute><BuyoutListPage /></AdminRoute>} />
-        <Route path="/buyout/calculator" element={<AdminRoute><BuyoutCalculatorPage /></AdminRoute>} />
+        <Route path="/buyout/calculator" element={<BuyoutCalculatorPage />} />
 
         {/* Assets */}
         <Route path="/assets" element={<AdminRoute><AssetListPage /></AdminRoute>} />

--- a/packages/client/src/routes.tsx
+++ b/packages/client/src/routes.tsx
@@ -1,6 +1,13 @@
 import { lazy } from "react";
-import { Route } from "react-router-dom";
+import { Route, Navigate } from "react-router-dom";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { isAdmin, EMPLOYEE_HOME } from "@/lib/auth-store";
+
+// Guards an admin-only page: employees are bounced to their self-service hub
+// instead of seeing an org-wide management console (or an empty, role-scoped one).
+function AdminRoute({ children }: { children: React.ReactNode }) {
+  return isAdmin() ? <>{children}</> : <Navigate to={EMPLOYEE_HOME} replace />;
+}
 
 // Lazy-loaded pages
 const LoginPage = lazy(() =>
@@ -140,67 +147,70 @@ export function AppRoutes() {
       {/* Public auth */}
       <Route path="/login" element={<LoginPage />} />
 
-      {/* Protected routes inside DashboardLayout */}
+      {/* Protected routes inside DashboardLayout.
+          Self-service pages (/exits/my, /interviews/my, /kt/my, /alumni/my,
+          /exits/resign) are open to employees; everything else is wrapped in
+          <AdminRoute> so employees are redirected to their own hub. */}
       <Route element={<DashboardLayout />}>
-        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/dashboard" element={<AdminRoute><DashboardPage /></AdminRoute>} />
 
         {/* Exits */}
-        <Route path="/exits" element={<ExitListPage />} />
-        <Route path="/exits/new" element={<InitiateExitPage />} />
+        <Route path="/exits" element={<AdminRoute><ExitListPage /></AdminRoute>} />
+        <Route path="/exits/new" element={<AdminRoute><InitiateExitPage /></AdminRoute>} />
         <Route path="/exits/resign" element={<ResignationPage />} />
         <Route path="/exits/my" element={<MyExitPage />} />
-        <Route path="/exits/:id" element={<ExitDetailPage />} />
+        <Route path="/exits/:id" element={<AdminRoute><ExitDetailPage /></AdminRoute>} />
 
         {/* Checklists */}
-        <Route path="/checklists" element={<ChecklistTemplatesPage />} />
-        <Route path="/checklists/:id" element={<ChecklistInstancePage />} />
+        <Route path="/checklists" element={<AdminRoute><ChecklistTemplatesPage /></AdminRoute>} />
+        <Route path="/checklists/:id" element={<AdminRoute><ChecklistInstancePage /></AdminRoute>} />
 
         {/* Clearance */}
-        <Route path="/clearance" element={<ClearanceRecordsPage />} />
-        <Route path="/clearance/departments" element={<ClearanceDeptPage />} />
+        <Route path="/clearance" element={<AdminRoute><ClearanceRecordsPage /></AdminRoute>} />
+        <Route path="/clearance/departments" element={<AdminRoute><ClearanceDeptPage /></AdminRoute>} />
 
         {/* Interviews */}
-        <Route path="/interviews" element={<InterviewListPage />} />
-        <Route path="/interviews/templates" element={<InterviewTemplatesPage />} />
+        <Route path="/interviews" element={<AdminRoute><InterviewListPage /></AdminRoute>} />
+        <Route path="/interviews/templates" element={<AdminRoute><InterviewTemplatesPage /></AdminRoute>} />
         <Route path="/interviews/my" element={<MyExitInterviewPage />} />
-        <Route path="/interviews/:id" element={<InterviewDetailPage />} />
+        <Route path="/interviews/:id" element={<AdminRoute><InterviewDetailPage /></AdminRoute>} />
 
         {/* FnF */}
-        <Route path="/fnf" element={<FnFListPage />} />
-        <Route path="/fnf/:id" element={<FnFDetailPage />} />
+        <Route path="/fnf" element={<AdminRoute><FnFListPage /></AdminRoute>} />
+        <Route path="/fnf/:id" element={<AdminRoute><FnFDetailPage /></AdminRoute>} />
 
         {/* Buyout */}
-        <Route path="/buyout" element={<BuyoutListPage />} />
-        <Route path="/buyout/calculator" element={<BuyoutCalculatorPage />} />
+        <Route path="/buyout" element={<AdminRoute><BuyoutListPage /></AdminRoute>} />
+        <Route path="/buyout/calculator" element={<AdminRoute><BuyoutCalculatorPage /></AdminRoute>} />
 
         {/* Assets */}
-        <Route path="/assets" element={<AssetListPage />} />
+        <Route path="/assets" element={<AdminRoute><AssetListPage /></AdminRoute>} />
 
         {/* KT */}
-        <Route path="/kt" element={<KTListPage />} />
+        <Route path="/kt" element={<AdminRoute><KTListPage /></AdminRoute>} />
         <Route path="/kt/my" element={<MyKTPage />} />
-        <Route path="/kt/:id" element={<KTDetailPage />} />
+        <Route path="/kt/:id" element={<AdminRoute><KTDetailPage /></AdminRoute>} />
 
         {/* Letters */}
-        <Route path="/letters" element={<GeneratedLettersPage />} />
-        <Route path="/letters/templates" element={<LetterTemplatesPage />} />
+        <Route path="/letters" element={<AdminRoute><GeneratedLettersPage /></AdminRoute>} />
+        <Route path="/letters/templates" element={<AdminRoute><LetterTemplatesPage /></AdminRoute>} />
 
         {/* Alumni */}
-        <Route path="/alumni" element={<AlumniListPage />} />
+        <Route path="/alumni" element={<AdminRoute><AlumniListPage /></AdminRoute>} />
         <Route path="/alumni/my" element={<MyAlumniPage />} />
 
         {/* Rehire */}
-        <Route path="/rehire" element={<RehireListPage />} />
-        <Route path="/rehire/:id" element={<RehireDetailPage />} />
+        <Route path="/rehire" element={<AdminRoute><RehireListPage /></AdminRoute>} />
+        <Route path="/rehire/:id" element={<AdminRoute><RehireDetailPage /></AdminRoute>} />
 
         {/* Analytics */}
-        <Route path="/analytics" element={<AnalyticsPage />} />
-        <Route path="/analytics/nps" element={<NPSPage />} />
-        <Route path="/analytics/flight-risk" element={<AttritionPredictionPage />} />
-        <Route path="/analytics/flight-risk/:employeeId" element={<EmployeeRiskDetailPage />} />
+        <Route path="/analytics" element={<AdminRoute><AnalyticsPage /></AdminRoute>} />
+        <Route path="/analytics/nps" element={<AdminRoute><NPSPage /></AdminRoute>} />
+        <Route path="/analytics/flight-risk" element={<AdminRoute><AttritionPredictionPage /></AdminRoute>} />
+        <Route path="/analytics/flight-risk/:employeeId" element={<AdminRoute><EmployeeRiskDetailPage /></AdminRoute>} />
 
         {/* Settings */}
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/settings" element={<AdminRoute><SettingsPage /></AdminRoute>} />
       </Route>
 
       {/* 404 */}

--- a/packages/server/src/api/routes/asset.routes.ts
+++ b/packages/server/src/api/routes/asset.routes.ts
@@ -13,6 +13,23 @@ import { ValidationError } from "../../utils/errors";
 const router = Router();
 router.use(authenticate);
 
+// GET /assets — org-wide list of all asset returns (admin management view)
+router.get(
+  "/",
+  authorize("super_admin", "org_admin", "hr_admin", "hr_manager"),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      const assets = await assetService.listAllAssets(orgId, {
+        status: req.query.status as string | undefined,
+      });
+      return sendSuccess(res, assets);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // GET /assets/exit/:exitId — list assets for an exit
 router.get("/exit/:exitId", async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/packages/server/src/api/routes/fnf.routes.ts
+++ b/packages/server/src/api/routes/fnf.routes.ts
@@ -14,6 +14,23 @@ const router = Router();
 // All routes require authentication
 router.use(authenticate);
 
+// GET / — list all FnF settlements for the org (admin management view)
+router.get(
+  "/",
+  authorize("org_admin", "hr_admin", "hr_manager"),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      const list = await fnfService.listFnF(orgId, {
+        status: req.query.status as string | undefined,
+      });
+      sendSuccess(res, list);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // POST /exit/:exitId/calculate — calculate FnF for an exit
 router.post(
   "/exit/:exitId/calculate",

--- a/packages/server/src/api/routes/self-service.routes.ts
+++ b/packages/server/src/api/routes/self-service.routes.ts
@@ -15,6 +15,8 @@ import * as checklistService from "../../services/checklist/checklist.service";
 import * as buyoutService from "../../services/buyout/notice-buyout.service";
 import * as letterService from "../../services/letter/letter.service";
 import * as ktService from "../../services/kt/knowledge-transfer.service";
+import * as interviewService from "../../services/interview/exit-interview.service";
+import { submitInterviewResponseSchema } from "@emp-exit/shared";
 
 const router = Router();
 
@@ -287,6 +289,72 @@ router.put("/my-kt/complete", async (req, res, next) => {
     }
 
     const updated = await ktService.updateKT(orgId, exit.id, { status: "completed" });
+    sendSuccess(res, updated);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /my-interview — my exit interview plus its template/questions, resolved
+// from my own exit. Returns { interview, template } so the page needs one call
+// and never has to fetch the admin-only /interviews/templates/:id endpoint.
+router.get("/my-interview", async (req, res, next) => {
+  try {
+    const orgId = req.user!.empcloudOrgId;
+    const userId = req.user!.empcloudUserId;
+
+    const exit = await exitService.getMyExit(orgId, userId);
+    if (!exit) {
+      return sendSuccess(res, { interview: null, template: null });
+    }
+
+    const interview = await interviewService.getInterview(orgId, exit.id);
+    let template = null;
+    if (interview?.template_id) {
+      template = await interviewService.getTemplate(orgId, interview.template_id);
+    }
+
+    sendSuccess(res, { interview, template });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /my-interview/responses — submit answers to my own exit interview.
+// Ownership is enforced: the interview must belong to the requester's own exit.
+router.post("/my-interview/responses", async (req, res, next) => {
+  try {
+    const orgId = req.user!.empcloudOrgId;
+    const userId = req.user!.empcloudUserId;
+
+    const exit = await exitService.getMyExit(orgId, userId);
+    if (!exit) {
+      throw new NotFoundError("Exit interview", "");
+    }
+
+    const parsed = submitInterviewResponseSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new ValidationError("Invalid response data", {
+        validation: parsed.error.errors.map((e) => e.message),
+      });
+    }
+
+    const interview = await interviewService.getInterview(orgId, exit.id);
+    if (!interview) {
+      throw new NotFoundError("Exit interview", "");
+    }
+
+    const updated = await interviewService.submitResponses(
+      orgId,
+      interview.id,
+      parsed.data.responses.map((r) => ({
+        questionId: r.question_id,
+        responseText: r.answer_text,
+        responseRating: r.answer_rating,
+      })),
+      parsed.data.overall_rating,
+      req.body.would_recommend,
+    );
     sendSuccess(res, updated);
   } catch (err) {
     next(err);

--- a/packages/server/src/api/routes/self-service.routes.ts
+++ b/packages/server/src/api/routes/self-service.routes.ts
@@ -9,10 +9,12 @@ import { Router, Request, Response, NextFunction } from "express";
 import { authenticate } from "../middleware/auth.middleware";
 import { sendSuccess } from "../../utils/response";
 import { submitResignationSchema } from "@emp-exit/shared";
-import { ValidationError } from "../../utils/errors";
+import { ValidationError, NotFoundError } from "../../utils/errors";
 import * as exitService from "../../services/exit/exit-request.service";
 import * as checklistService from "../../services/checklist/checklist.service";
 import * as buyoutService from "../../services/buyout/notice-buyout.service";
+import * as letterService from "../../services/letter/letter.service";
+import * as ktService from "../../services/kt/knowledge-transfer.service";
 
 const router = Router();
 
@@ -158,5 +160,137 @@ router.get(
     }
   },
 );
+
+// GET /my-letters — list the letters generated for my exit
+router.get(
+  "/my-letters",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      const userId = req.user!.empcloudUserId;
+
+      const exit = await exitService.getMyExit(orgId, userId);
+      if (!exit) {
+        return sendSuccess(res, []);
+      }
+
+      const letters = await letterService.listLetters(orgId, exit.id);
+      sendSuccess(res, letters);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// GET /my-letters/:letterId/download — download one of MY letters as HTML.
+// Verifies the letter belongs to the requesting employee's own exit before
+// serving it (a self-service user must not read another employee's letter).
+router.get(
+  "/my-letters/:letterId/download",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      const userId = req.user!.empcloudUserId;
+
+      const exit = await exitService.getMyExit(orgId, userId);
+      if (!exit) {
+        throw new NotFoundError("Generated letter", req.params.letterId as string);
+      }
+
+      const letter = (await letterService.getLetter(orgId, req.params.letterId as string)) as any;
+      // Ownership guard: the letter must belong to THIS employee's exit.
+      if (letter.exit_request_id !== exit.id) {
+        throw new NotFoundError("Generated letter", req.params.letterId as string);
+      }
+
+      res.setHeader("Content-Type", "text/html");
+      res.setHeader("Content-Disposition", `attachment; filename="${letter.letter_type}_letter.html"`);
+      return res.send(letter.generated_body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// GET /my-kt — the knowledge-transfer plan (with items) for my own exit.
+// Resolves the employee's exit server-side so no exitId is needed in the URL.
+router.get("/my-kt", async (req, res, next) => {
+  try {
+    const orgId = req.user!.empcloudOrgId;
+    const userId = req.user!.empcloudUserId;
+
+    const exit = await exitService.getMyExit(orgId, userId);
+    if (!exit) {
+      return sendSuccess(res, null);
+    }
+
+    const kt = await ktService.getKT(orgId, exit.id);
+    sendSuccess(res, kt);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /my-kt/items/:itemId — let the employee mark their own KT item
+// complete / reopen. Ownership is enforced: the item's KT must belong to
+// the requester's own exit.
+router.put("/my-kt/items/:itemId", async (req, res, next) => {
+  try {
+    const orgId = req.user!.empcloudOrgId;
+    const userId = req.user!.empcloudUserId;
+
+    const exit = await exitService.getMyExit(orgId, userId);
+    if (!exit) {
+      throw new NotFoundError("Knowledge transfer item", req.params.itemId as string);
+    }
+
+    const kt = await ktService.getKT(orgId, exit.id);
+    const ownsItem = kt?.items?.some((i: any) => i.id === req.params.itemId);
+    if (!ownsItem) {
+      throw new NotFoundError("Knowledge transfer item", req.params.itemId as string);
+    }
+
+    const status = req.body?.status;
+    if (status !== "not_started" && status !== "in_progress" && status !== "completed") {
+      throw new ValidationError("status must be not_started, in_progress, or completed");
+    }
+
+    const item = await ktService.updateItem(orgId, req.params.itemId as string, { status });
+    sendSuccess(res, item);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /my-kt/complete — employee formally marks their whole KT plan complete.
+// Guarded: only allowed once every KT item is completed (the UI enforces this
+// too, but we re-check server-side so the plan can't be closed with open items).
+router.put("/my-kt/complete", async (req, res, next) => {
+  try {
+    const orgId = req.user!.empcloudOrgId;
+    const userId = req.user!.empcloudUserId;
+
+    const exit = await exitService.getMyExit(orgId, userId);
+    if (!exit) {
+      throw new NotFoundError("Knowledge transfer plan", "");
+    }
+
+    const kt = await ktService.getKT(orgId, exit.id);
+    if (!kt) {
+      throw new NotFoundError("Knowledge transfer plan", "");
+    }
+
+    const items = kt.items ?? [];
+    const allDone = items.length > 0 && items.every((i: any) => i.status === "completed");
+    if (!allDone) {
+      throw new ValidationError("All KT items must be completed before finishing the KT.");
+    }
+
+    const updated = await ktService.updateKT(orgId, exit.id, { status: "completed" });
+    sendSuccess(res, updated);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export { router as selfServiceRoutes };

--- a/packages/server/src/services/alumni/alumni.service.ts
+++ b/packages/server/src/services/alumni/alumni.service.ts
@@ -124,17 +124,27 @@ export async function listAlumni(
     return { data, total: Number(total), page, perPage };
   }
 
-  const result = await db.findMany("alumni_profiles", {
-    filters: { organization_id: orgId, opted_in: true },
-    page,
-    limit: perPage,
-    sort: { field: "created_at", order: "desc" },
-  });
+  // Default listing — JOIN empcloud.users so names/department resolve, matching
+  // the search path. (Previously this used findMany without the JOIN, so the UI
+  // fell back to "Employee #<id>" with a blank department until you searched.)
+  const rows = await db.raw<any>(
+    `SELECT ap.*, u.first_name, u.last_name, u.email as work_email
+     FROM alumni_profiles ap
+     LEFT JOIN empcloud.users u ON u.id = ap.employee_id
+     WHERE ap.organization_id = ? AND ap.opted_in = 1
+     ORDER BY ap.created_at DESC
+     LIMIT ? OFFSET ?`,
+    [orgId, perPage, (page - 1) * perPage],
+  );
 
-  return {
-    data: result.data,
-    total: result.total,
-    page: result.page,
-    perPage,
-  };
+  const [countResult] = await db.raw<any>(
+    `SELECT COUNT(*) as total FROM alumni_profiles ap
+     WHERE ap.organization_id = ? AND ap.opted_in = 1`,
+    [orgId],
+  );
+
+  const data = Array.isArray(rows) && Array.isArray(rows[0]) ? rows[0] : rows;
+  const total = countResult?.[0]?.total || 0;
+
+  return { data, total: Number(total), page, perPage };
 }

--- a/packages/server/src/services/asset/asset-return.service.ts
+++ b/packages/server/src/services/asset/asset-return.service.ts
@@ -4,6 +4,7 @@
 // ============================================================================
 
 import { getDB } from "../../db/adapters";
+import { getEmpCloudDB } from "../../db/empcloud";
 import { NotFoundError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 
@@ -72,6 +73,62 @@ export async function listAssets(orgId: number, exitRequestId: string) {
   });
 
   return result.data;
+}
+
+/**
+ * List every asset across the org, enriched with the owning employee + exit
+ * status, so the standalone /assets page can show an org-wide table instead of
+ * a dead-end "open an exit" card. Optional status filter.
+ */
+export async function listAllAssets(
+  orgId: number,
+  params: { status?: string } = {},
+) {
+  const db = getDB();
+
+  // Assets are scoped to the org via their exit request.
+  const exitsResult = await db.findMany<any>("exit_requests", {
+    filters: { organization_id: orgId },
+    limit: 1000,
+  });
+  const exitById = new Map(exitsResult.data.map((e) => [e.id, e]));
+  const exitIds = exitsResult.data.map((e) => e.id);
+  if (exitIds.length === 0) return [];
+
+  const assetFilters: Record<string, any> = { exit_request_id: exitIds };
+  if (params.status) assetFilters.status = params.status;
+
+  const assets = await db.findMany<any>("asset_returns", {
+    filters: assetFilters,
+    sort: { field: "created_at", order: "desc" },
+    limit: 1000,
+  });
+
+  // Enrich with employee names from EmpCloud.
+  const empDb = getEmpCloudDB();
+  const employeeIds = [
+    ...new Set(
+      assets.data
+        .map((a) => exitById.get(a.exit_request_id)?.employee_id)
+        .filter((id): id is number => typeof id === "number"),
+    ),
+  ];
+  const empMap = new Map<number, any>();
+  if (employeeIds.length > 0) {
+    const employees = await empDb("users")
+      .whereIn("id", employeeIds)
+      .select("id", "first_name", "last_name", "designation");
+    for (const e of employees) empMap.set(e.id, e);
+  }
+
+  return assets.data.map((a) => {
+    const exit = exitById.get(a.exit_request_id);
+    return {
+      ...a,
+      exit_status: exit?.status ?? null,
+      employee: exit ? empMap.get(exit.employee_id) ?? null : null,
+    };
+  });
 }
 
 export async function updateAsset(

--- a/packages/server/src/services/clearance/clearance.service.ts
+++ b/packages/server/src/services/clearance/clearance.service.ts
@@ -4,6 +4,7 @@
 // ============================================================================
 
 import { getDB } from "../../db/adapters";
+import { getEmpCloudDB } from "../../db/empcloud";
 import { NotFoundError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 import { sendClearancePendingEmail, sendClearanceCompletedEmail } from "../email/exit-email.service";
@@ -270,8 +271,31 @@ export async function getMyClearances(orgId: number, userId: number) {
     departments.filter(Boolean).map((d) => [d!.id, d!]),
   );
 
-  return filtered.map((record) => ({
-    ...record,
-    department: deptMap.get(record.department_id) || null,
-  }));
+  // Enrich with the exit's employee (name) so the UI shows who the clearance is
+  // for, not a raw exit UUID.
+  const exitMap = new Map(exits.filter(Boolean).map((e) => [e!.id, e!]));
+  const employeeIds = [
+    ...new Set(
+      filtered
+        .map((r) => exitMap.get(r.exit_request_id)?.employee_id)
+        .filter((id): id is number => typeof id === "number"),
+    ),
+  ];
+  const empMap = new Map<number, any>();
+  if (employeeIds.length > 0) {
+    const empDb = getEmpCloudDB();
+    const employees = await empDb("users")
+      .whereIn("id", employeeIds)
+      .select("id", "first_name", "last_name", "designation");
+    for (const e of employees) empMap.set(e.id, e);
+  }
+
+  return filtered.map((record) => {
+    const exit = exitMap.get(record.exit_request_id);
+    return {
+      ...record,
+      department: deptMap.get(record.department_id) || null,
+      employee: exit ? empMap.get(exit.employee_id) ?? null : null,
+    };
+  });
 }

--- a/packages/server/src/services/exit/exit-request.service.ts
+++ b/packages/server/src/services/exit/exit-request.service.ts
@@ -156,7 +156,20 @@ export async function listExits(
   const filters: Record<string, any> = { organization_id: orgId };
 
   if (params.status) {
-    filters.status = params.status;
+    // "active" is a virtual group (matches the dashboard's Active Exits count):
+    // any exit still in progress, i.e. not completed/cancelled. Expands to a
+    // status IN (...) filter; the adapter turns an array value into whereIn.
+    if (params.status === "active") {
+      filters.status = [
+        "initiated",
+        "notice_period",
+        "clearance_pending",
+        "fnf_pending",
+        "fnf_processed",
+      ];
+    } else {
+      filters.status = params.status;
+    }
   }
   if (params.exit_type) {
     filters.exit_type = params.exit_type;

--- a/packages/server/src/services/fnf/fnf.service.ts
+++ b/packages/server/src/services/fnf/fnf.service.ts
@@ -5,7 +5,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { getDB } from "../../db/adapters";
-import { findUserById } from "../../db/empcloud";
+import { findUserById, getEmpCloudDB } from "../../db/empcloud";
 import { NotFoundError, ValidationError, ConflictError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 import { sendFnFCalculatedEmail, sendFnFApprovedEmail } from "../email/exit-email.service";
@@ -353,4 +353,66 @@ export async function markPaid(
 
   logger.info(`FnF marked as paid for exit ${exitRequestId}, ref: ${paymentReference}`);
   return updated;
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+/**
+ * List FnF settlements for an org, enriched with the employee + exit context
+ * (status, last working date) so the UI can render a manageable list instead of
+ * forcing an admin to look settlements up by raw exit UUID.
+ */
+export async function listFnF(
+  orgId: number,
+  params: { status?: string } = {},
+): Promise<any[]> {
+  const db = getDB();
+
+  // FnF rows are scoped to the org via their exit request.
+  const exitFilters: Record<string, any> = { organization_id: orgId };
+  const exitsResult = await db.findMany<ExitRequest>("exit_requests", {
+    filters: exitFilters,
+    limit: 1000,
+  });
+  const exitById = new Map(exitsResult.data.map((e) => [e.id, e]));
+  const exitIds = exitsResult.data.map((e) => e.id);
+  if (exitIds.length === 0) return [];
+
+  const settlementFilters: Record<string, any> = { exit_request_id: exitIds };
+  if (params.status) settlementFilters.status = params.status;
+
+  const settlements = await db.findMany<FnFSettlement>("fnf_settlements", {
+    filters: settlementFilters,
+    sort: { field: "updated_at", order: "desc" },
+    limit: 1000,
+  });
+
+  // Enrich with employee details from EmpCloud.
+  const empDb = getEmpCloudDB();
+  const employeeIds = [
+    ...new Set(
+      settlements.data
+        .map((f) => exitById.get(f.exit_request_id)?.employee_id)
+        .filter((id): id is number => typeof id === "number"),
+    ),
+  ];
+  const empMap = new Map<number, any>();
+  if (employeeIds.length > 0) {
+    const employees = await empDb("users")
+      .whereIn("id", employeeIds)
+      .select("id", "first_name", "last_name", "email", "emp_code", "designation");
+    for (const e of employees) empMap.set(e.id, e);
+  }
+
+  return settlements.data.map((f) => {
+    const exit = exitById.get(f.exit_request_id);
+    return {
+      ...f,
+      exit_status: exit?.status ?? null,
+      last_working_date: exit?.last_working_date ?? null,
+      employee: exit ? empMap.get(exit.employee_id) ?? null : null,
+    };
+  });
 }


### PR DESCRIPTION
Improves the EMP Exit module on two fronts: wires the employee role into the app so employees get a real self-service experience, and fixes several admin pages that were broken placeholders or had data/UX bugs (found while auditing the module).

== Employee self-service ==

Problem: employees were routed to the admin dashboard and could reach org-wide management pages; the existing "My ..." self-service pages had no nav path, and some required an exit UUID in the URL.

- Role helpers (isAdmin / isEmployee / homeFor) as a single source of truth.
- After login (normal + SSO), admins go to /dashboard, employees to /exits/my.
- AdminRoute guard wraps every admin page; employees hitting an admin URL are redirected to their own hub.
- Sidebar split: employees see only My Exit, My Interview, My KT, Alumni; admins keep the full console.
- My Documents: employee-scoped GET /self-service/my-letters (+ /:id/download) with an ownership guard; MyExitPage lists downloadable letters.
- My KT: self-service GET /my-kt, item toggle, and a guarded "Mark KT as Complete" action (confirmation + locks items). Resolves the employee's own exit server-side (no exitId in URL).
- My Interview: was unusable (it fetched the question list from an admin-only template endpoint that 403'd for employees). New GET /self-service/my-interview returns interview + template in one call; POST /my-interview/responses with an ownership guard. Form locks once submitted.

== Admin page fixes ==

- Active Exits filter: the dashboard card counts a group of in-progress statuses but linked to /exits?status=active, which the API treated as a literal equality filter (no exit has status "active") so the list showed 0. listExits now expands "active" to the same 5-status set the dashboard counts, and the Exits dropdown gets an "Active (in progress)" option.
- FnF list: the page was a placeholder (look-up-by-UUID box, no list). Added GET /fnf (admin-gated) returning all settlements enriched with employee + exit context; FnFListPage is now a real table with a status filter and detail links.
- Assets list: the /assets route only loaded data when an exitId was in the URL, so the sidebar link was a dead end. Added GET /assets (admin-gated, org-wide, enriched with employee) and an org-wide table on AssetListPage; the per-exit flow is unchanged.
- Alumni names: the default alumni listing showed "Employee #<id>" with a blank department because the no-search branch skipped the empcloud.users JOIN. Default listing now uses the same JOIN so names/department always resolve.

== Testing ==

- Client and server typecheck clean throughout.
- Every new/changed endpoint verified end-to-end against seeded employee and org-admin tokens: self-service letters/KT/interview, the active-exits group filter, the FnF and Assets org-wide lists, and Alumni name resolution.
- Ownership/role guards confirmed: foreign ids return 404; admin-only lists return 403 for employees; the KT complete route returns 400 while any item is open.
