### PR TITLE
feat(exit): employee resignation withdraw + form-default fix

### DIFF
--- a/packages/client/src/pages/exits/MyExitPage.tsx
+++ b/packages/client/src/pages/exits/MyExitPage.tsx
@@ -63,6 +63,8 @@ export function MyExitPage() {
   const [letters, setLetters] = useState<any[]>([]);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [confirmWithdraw, setConfirmWithdraw] = useState(false);
+  const [withdrawing, setWithdrawing] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -125,6 +127,23 @@ export function MyExitPage() {
     }
   }
 
+  async function handleWithdraw() {
+    setWithdrawing(true);
+    try {
+      const res = await api.post("/self-service/my-exit/withdraw");
+      setExit(res.data?.data ?? null);
+      toast.success("Resignation withdrawn");
+      setConfirmWithdraw(false);
+    } catch (err: any) {
+      toast.error(err.response?.data?.error?.message || "Failed to withdraw resignation");
+    } finally {
+      setWithdrawing(false);
+    }
+  }
+
+  // Employees can withdraw their own resignation only while it's still early.
+  const canWithdraw = exit && (exit.status === "initiated" || exit.status === "notice_period");
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -180,6 +199,15 @@ export function MyExitPage() {
               {exit.exit_type?.replace(/_/g, " ")} &middot; {exit.reason_category?.replace(/_/g, " ")}
             </p>
           </div>
+          {canWithdraw && (
+            <button
+              onClick={() => setConfirmWithdraw(true)}
+              className="inline-flex items-center gap-1.5 self-start rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50"
+            >
+              <UserMinus className="h-3.5 w-3.5" />
+              Withdraw Resignation
+            </button>
+          )}
         </div>
 
         <div className="mt-5 grid grid-cols-2 gap-4 sm:grid-cols-4">
@@ -368,6 +396,36 @@ export function MyExitPage() {
                 </button>
               </div>
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* Withdraw confirmation */}
+      {confirmWithdraw && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-gray-900">Withdraw Resignation?</h3>
+            <p className="mt-2 text-sm text-gray-500">
+              This cancels your exit request. Your manager and HR will be notified. You can submit a
+              new resignation later if needed.
+            </p>
+            <div className="mt-5 flex justify-end gap-3">
+              <button
+                onClick={() => setConfirmWithdraw(false)}
+                disabled={withdrawing}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Keep Resignation
+              </button>
+              <button
+                onClick={handleWithdraw}
+                disabled={withdrawing}
+                className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {withdrawing && <Loader2 className="h-4 w-4 animate-spin" />}
+                Withdraw
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/packages/client/src/pages/exits/ResignationPage.tsx
+++ b/packages/client/src/pages/exits/ResignationPage.tsx
@@ -20,7 +20,7 @@ export function ResignationPage() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
-  const [reasonCategory, setReasonCategory] = useState("better_opportunity");
+  const [reasonCategory, setReasonCategory] = useState("");
   const [reasonDetail, setReasonDetail] = useState("");
   const [resignationDate, setResignationDate] = useState(
     new Date().toISOString().split("T")[0],
@@ -89,10 +89,12 @@ export function ResignationPage() {
             </label>
             <select
               id="reason_category"
+              required
               value={reasonCategory}
               onChange={(e) => setReasonCategory(e.target.value)}
               className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
             >
+              <option value="" disabled>Select a reason…</option>
               {REASON_CATEGORIES.map((r) => (
                 <option key={r.value} value={r.value}>{r.label}</option>
               ))}
@@ -151,7 +153,7 @@ export function ResignationPage() {
         <div className="flex items-center gap-3">
           <button
             type="submit"
-            disabled={submitting || !resignationDate}
+            disabled={submitting || !resignationDate || !reasonCategory}
             className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-5 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-rose-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {submitting ? (

--- a/packages/server/src/api/routes/self-service.routes.ts
+++ b/packages/server/src/api/routes/self-service.routes.ts
@@ -60,6 +60,34 @@ router.get(
   },
 );
 
+// POST /my-exit/withdraw — withdraw (cancel) my own resignation.
+// Only allowed while the exit is still early (initiated / notice_period); once
+// clearance or F&F has started the employee can no longer self-withdraw.
+router.post(
+  "/my-exit/withdraw",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      const userId = req.user!.empcloudUserId;
+
+      const exit = await exitService.getMyExit(orgId, userId);
+      if (!exit) {
+        throw new NotFoundError("Exit request", "");
+      }
+      if (exit.status !== "initiated" && exit.status !== "notice_period") {
+        throw new ValidationError(
+          "This resignation can no longer be withdrawn. Please contact HR.",
+        );
+      }
+
+      const cancelled = await exitService.cancelExit(orgId, exit.id);
+      sendSuccess(res, cancelled);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // GET /my-checklist — get my exit checklist
 router.get(
   "/my-checklist",

--- a/packages/server/src/services/exit/exit-request.service.ts
+++ b/packages/server/src/services/exit/exit-request.service.ts
@@ -414,14 +414,19 @@ export async function submitResignation(
 export async function getMyExit(orgId: number, userId: number) {
   const db = getDB();
 
-  const exit = await db.findOne<ExitRequest>("exit_requests", {
-    organization_id: orgId,
-    employee_id: userId,
+  // An employee may have an old cancelled exit plus a new one after re-submitting,
+  // so fetch all their exits and pick the most recent non-cancelled one rather
+  // than relying on findOne's (unordered) first row.
+  const result = await db.findMany<ExitRequest>("exit_requests", {
+    filters: { organization_id: orgId, employee_id: userId },
+    sort: { field: "created_at", order: "desc" },
+    limit: 50,
   });
 
-  if (!exit || exit.status === "cancelled") {
+  const active = result.data.find((e) => e.status !== "cancelled");
+  if (!active) {
     return null;
   }
 
-  return getExit(orgId, exit.id);
+  return getExit(orgId, active.id);
 }


### PR DESCRIPTION
Fixes two problems in the employee self-service resignation flow.

== Resignation form submitted un-chosen defaults ==

The form pre-selected a reason ("Better Opportunity") and today's date, so clicking Submit without touching anything sent those values â€” it appeared a blank/accidental resignation went through.

- The reason category now starts empty with a "Select a reasonâ€¦" placeholder and is required.
- The Submit button stays disabled until a reason is chosen (in addition to the existing date requirement), so nothing submits by accident.

== No way to withdraw a resignation ==

Once submitted, the employee had no way to undo it (only admins could cancel an exit).

- Add POST /self-service/my-exit/withdraw, which cancels the requesting employee's own exit. Guarded: only allowed while the exit is still early (initiated / notice_period); once clearance or F&F has started it returns a "contact HR" message. Reuses the existing cancelExit service (org-scoped).
- MyExitPage shows a "Withdraw Resignation" button (only when withdrawable) with a confirmation dialog. After withdrawing, getMyExit returns null so the page falls back to the empty state, where the employee can submit a fresh resignation.

== Hardening: getMyExit ==

After a withdraw + re-submit, an employee can have both a cancelled and a new exit row. getMyExit previously used an unordered findOne and could surface the stale cancelled row (showing "no exit" while an active one existed). It now returns the most recent non-cancelled exit.

== Testing ==

- Client and server typecheck clean.
- Verified end-to-end against an employee token: withdraw moves initiated -> cancelled (200) and is then blocked; with both a cancelled and an active row, my-exit returns the active one; with all rows cancelled, my-exit returns null (empty state); re-submitting after a withdraw creates a fresh initiated exit.
