### PR TITLE
feat(exit): real interviews list + readable FnF/interview detail views

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -17,16 +17,22 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// Handle 401 — redirect to login (but skip for SSO exchange requests)
+// Handle 401 — the session expired or the token is invalid. Clear it and send
+// the user to login with a flag so the login page can explain why. Skipped for
+// the SSO exchange and for the login request itself (a 401 there means bad
+// credentials, which the login page surfaces directly — not "session expired").
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const requestUrl = error.config?.url || "";
-    if (error.response?.status === 401 && !requestUrl.includes("/auth/sso")) {
+    const isAuthRequest = requestUrl.includes("/auth/sso") || requestUrl.includes("/auth/login");
+    const hadSession = !!localStorage.getItem("access_token");
+
+    if (error.response?.status === 401 && !isAuthRequest && hadSession) {
       localStorage.removeItem("access_token");
       localStorage.removeItem("refresh_token");
       localStorage.removeItem("user");
-      window.location.href = "/login";
+      window.location.href = "/login?session=expired";
     }
     return Promise.reject(error);
   }

--- a/packages/client/src/pages/auth/LoginPage.tsx
+++ b/packages/client/src/pages/auth/LoginPage.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { DoorOpen, Eye, EyeOff, Loader2 } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { DoorOpen, Eye, EyeOff, Loader2, AlertCircle } from "lucide-react";
 import { useLogin } from "@/api/hooks";
-import { useAuthStore } from "@/lib/auth-store";
+import { useAuthStore, homeFor } from "@/lib/auth-store";
 import toast from "react-hot-toast";
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const sessionExpired = searchParams.get("session") === "expired";
   const loginMutation = useLogin();
   const login = useAuthStore((s) => s.login);
   const [email, setEmail] = useState("");
@@ -20,7 +22,7 @@ export function LoginPage() {
       if (res.success) {
         login(res.data.user, res.data.tokens);
         toast.success(`Welcome back, ${res.data.user.firstName}!`);
-        navigate("/dashboard");
+        navigate(homeFor(res.data.user));
       } else {
         toast.error(res.error?.message || "Login failed");
       }
@@ -81,6 +83,13 @@ export function LoginPage() {
           <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
             <h2 className="text-2xl font-bold text-gray-900">Welcome back</h2>
             <p className="mt-1 text-sm text-gray-500">Sign in to manage employee exits</p>
+
+            {sessionExpired && (
+              <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-sm text-amber-800">
+                <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <span>Your session has expired. Please log in again.</span>
+              </div>
+            )}
 
             <form onSubmit={handleSubmit} className="mt-6 space-y-4">
               <div>

--- a/packages/client/src/pages/buyout/BuyoutListPage.tsx
+++ b/packages/client/src/pages/buyout/BuyoutListPage.tsx
@@ -155,7 +155,9 @@ export function BuyoutListPage() {
                     <tr key={b.id} className="hover:bg-gray-50">
                       <td className="whitespace-nowrap px-6 py-4">
                         <p className="text-sm font-medium text-gray-900">
-                          Employee #{b.employee_id}
+                          {b.employee
+                            ? `${b.employee.first_name} ${b.employee.last_name}`
+                            : `Employee #${b.employee_id}`}
                         </p>
                         <p className="text-xs text-gray-500">Exit: {b.exit_request_id?.slice(0, 8)}...</p>
                       </td>

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -13,6 +13,7 @@ import {
   Package,
   BookOpen,
   FileSignature,
+  Settings2,
   ArrowLeft,
   Clock,
   Pencil,
@@ -1007,7 +1008,8 @@ function FnFTab({
   }, [fnf]);
 
   const isPaid = fnf?.status === "paid";
-  const isEditable = !isPaid;
+  // Lock amounts once the settlement is approved or paid.
+  const isEditable = !isPaid && fnf?.status !== "approved";
   const totalEarnings = basicSalaryDue + leaveEncashment + gratuity + bonusDue + otherEarnings;
   const totalDeductions = noticePayRecovery + otherDeductions;
   const netPayable = totalEarnings - totalDeductions;
@@ -1242,13 +1244,15 @@ function FnFTab({
               <RefreshCw className="h-4 w-4" /> Recalculate
             </button>
           )}
-          <button
-            onClick={handleSave}
-            disabled={actionLoading}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
-          >
-            {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />} Save Changes
-          </button>
+          {isEditable && (
+            <button
+              onClick={handleSave}
+              disabled={actionLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+            >
+              {actionLoading && <Loader2 className="h-4 w-4 animate-spin" />} Save Changes
+            </button>
+          )}
           {fnf.status === "calculated" && (
             <button
               onClick={() => setPendingAction("approve")}
@@ -2098,13 +2102,47 @@ function LettersTab({
       {/* Generate control */}
       <div className="flex flex-wrap items-end gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
         {!canGenerate ? (
-          <p className="text-sm text-gray-500">
-            Letters can be generated once the exit is <b>completed</b> — finish clearance and the
-            full &amp; final settlement, then mark the exit complete.
-          </p>
+          <div className="w-full space-y-3">
+            <p className="text-sm text-gray-500">
+              Letters can be generated once the exit is <b>completed</b> — finish clearance and the
+              full &amp; final settlement, then mark the exit complete.
+            </p>
+            {templates.length > 0 ? (
+              <div>
+                <p className="mb-1.5 text-xs font-medium text-gray-600">
+                  Templates that will be available:
+                </p>
+                <ul className="flex flex-wrap gap-2">
+                  {templates.map((t) => (
+                    <li
+                      key={t.id}
+                      className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs text-gray-700"
+                    >
+                      <FileSignature className="h-3 w-3 text-rose-500" />
+                      {t.name}
+                      <span className="text-gray-400">({LETTER_TYPES[t.letter_type] || t.letter_type})</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              <p className="text-xs text-gray-400">No letter templates configured yet.</p>
+            )}
+            <Link
+              to="/letters/templates"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-rose-600 hover:text-rose-700 hover:underline"
+            >
+              <Settings2 className="h-3.5 w-3.5" />
+              Manage letter templates
+            </Link>
+          </div>
         ) : templates.length === 0 ? (
           <p className="text-sm text-gray-500">
-            No letter templates available. Create one in Letter Templates first.
+            No letter templates available.{" "}
+            <Link to="/letters/templates" className="font-medium text-rose-600 hover:underline">
+              Create one in Letter Templates
+            </Link>{" "}
+            first.
           </p>
         ) : (
           <>

--- a/packages/client/src/pages/exits/ExitDetailPage.tsx
+++ b/packages/client/src/pages/exits/ExitDetailPage.tsx
@@ -1099,8 +1099,9 @@ function FnFTab({
           value={value / 100}
           onChange={(e) => onChange(Math.round(parseFloat(e.target.value || "0") * 100))}
           disabled={!isEditable}
+          readOnly={!isEditable}
           step="0.01"
-          className="w-32 rounded border border-gray-300 px-2 py-1 text-right text-sm font-mono focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500 disabled:bg-gray-50 disabled:text-gray-500"
+          className="w-32 rounded border border-gray-300 px-2 py-1 text-right text-sm font-mono focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500 disabled:bg-gray-50 disabled:text-gray-500 read-only:bg-gray-50 read-only:text-gray-500"
         />
       </div>
     </div>

--- a/packages/client/src/pages/exits/InitiateExitPage.tsx
+++ b/packages/client/src/pages/exits/InitiateExitPage.tsx
@@ -54,8 +54,24 @@ export function InitiateExitPage() {
   const [reasonDetail, setReasonDetail] = useState("");
   const [resignationDate, setResignationDate] = useState("");
   const [lastWorkingDate, setLastWorkingDate] = useState("");
+  // Tracks whether the admin has manually overridden the auto-suggested LWD,
+  // so we stop recomputing it from resignation date + notice period.
+  const [lwdManuallySet, setLwdManuallySet] = useState(false);
   const [noticePeriodDays, setNoticePeriodDays] = useState("30");
   const [noticePeriodWaived, setNoticePeriodWaived] = useState(false);
+
+  // Auto-suggest Last Working Date = Resignation Date + Notice Period.
+  // This is the normal flow (resign → serve notice → leave) and stops admins
+  // from typing an LWD that's before the resignation date. The admin can still
+  // override it; once they do, we leave their value alone.
+  useEffect(() => {
+    if (lwdManuallySet || !resignationDate) return;
+    const days = noticePeriodWaived ? 0 : Number(noticePeriodDays) || 0;
+    const d = new Date(resignationDate);
+    if (isNaN(d.getTime())) return;
+    d.setDate(d.getDate() + days);
+    setLastWorkingDate(d.toISOString().split("T")[0]);
+  }, [resignationDate, noticePeriodDays, noticePeriodWaived, lwdManuallySet]);
 
   // Debounced employee search (300ms). Discards stale responses by
   // comparing against the latest query at resolve time.
@@ -309,10 +325,15 @@ export function InitiateExitPage() {
                 id="last_working_date"
                 type="date"
                 value={lastWorkingDate}
-                onChange={(e) => setLastWorkingDate(e.target.value)}
+                onChange={(e) => { setLastWorkingDate(e.target.value); setLwdManuallySet(true); }}
                 min={resignationDate || undefined}
                 className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
               />
+              {resignationDate && !lwdManuallySet && lastWorkingDate && !dateError && (
+                <p className="mt-1 text-xs text-gray-400">
+                  Suggested from resignation date + {noticePeriodWaived ? "0 (waived)" : `${noticePeriodDays || 0}`} day notice.
+                </p>
+              )}
             </div>
           </div>
 

--- a/packages/client/src/pages/fnf/FnFDetailPage.tsx
+++ b/packages/client/src/pages/fnf/FnFDetailPage.tsx
@@ -30,6 +30,64 @@ function formatCurrency(amount: number): string {
   }).format(rupees);
 }
 
+// Renders the FnF breakdown_json as a friendly label/value list instead of a
+// raw JSON dump. Known keys get a human label + typed formatting; anything
+// unrecognized still shows, so nothing is hidden.
+const BREAKDOWN_FIELDS: { key: string; label: string; type: "money" | "date" | "days" | "bool" }[] = [
+  { key: "last_basic_salary", label: "Last Basic Salary", type: "money" },
+  { key: "date_of_joining", label: "Date of Joining", type: "date" },
+  { key: "lwd", label: "Last Working Date", type: "date" },
+  { key: "notice_start_date", label: "Notice Period Start", type: "date" },
+  { key: "notice_days", label: "Notice Period", type: "days" },
+  { key: "notice_waived", label: "Notice Waived", type: "bool" },
+  { key: "calculated_at", label: "Calculated On", type: "date" },
+];
+
+function CalculationDetails({ raw }: { raw: string }) {
+  let data: Record<string, any>;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return <p className="text-xs text-gray-400">No calculation details available.</p>;
+  }
+
+  const fmt = (type: string, value: any): string => {
+    if (value === null || value === undefined || value === "") return "—";
+    switch (type) {
+      case "money":
+        return formatCurrency(Number(value) || 0);
+      case "date":
+        return formatDate(value);
+      case "days":
+        return `${value} days`;
+      case "bool":
+        return value === 1 || value === true || value === "1" ? "Yes" : "No";
+      default:
+        return String(value);
+    }
+  };
+
+  const known = new Set(BREAKDOWN_FIELDS.map((f) => f.key));
+  const extras = Object.keys(data).filter((k) => !known.has(k));
+
+  return (
+    <dl className="grid grid-cols-1 gap-x-8 gap-y-2.5 sm:grid-cols-2">
+      {BREAKDOWN_FIELDS.filter((f) => f.key in data).map((f) => (
+        <div key={f.key} className="flex items-center justify-between border-b border-gray-50 py-1">
+          <dt className="text-xs text-gray-500">{f.label}</dt>
+          <dd className="text-sm font-medium text-gray-900">{fmt(f.type, data[f.key])}</dd>
+        </div>
+      ))}
+      {extras.map((k) => (
+        <div key={k} className="flex items-center justify-between border-b border-gray-50 py-1">
+          <dt className="text-xs text-gray-500">{k.replace(/_/g, " ")}</dt>
+          <dd className="text-sm font-medium text-gray-900">{String(data[k])}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
 export function FnFDetailPage() {
   const { id: exitId } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -372,10 +430,8 @@ export function FnFDetailPage() {
           {/* Breakdown info */}
           {fnf.breakdown_json && (
             <div className="rounded-lg border border-gray-200 bg-white p-5">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">Calculation Details</h3>
-              <pre className="text-xs text-gray-500 bg-gray-50 rounded p-3 overflow-x-auto">
-                {JSON.stringify(JSON.parse(fnf.breakdown_json), null, 2)}
-              </pre>
+              <h3 className="text-sm font-medium text-gray-700 mb-3">Calculation Details</h3>
+              <CalculationDetails raw={fnf.breakdown_json} />
             </div>
           )}
 

--- a/packages/client/src/pages/fnf/FnFDetailPage.tsx
+++ b/packages/client/src/pages/fnf/FnFDetailPage.tsx
@@ -230,7 +230,8 @@ export function FnFDetailPage() {
           value={value / 100}
           onChange={(e) => onChange(Math.round(parseFloat(e.target.value || "0") * 100))}
           disabled={disabled || !isEditable}
-          className="w-32 rounded border border-gray-300 px-2 py-1 text-right text-sm font-mono focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500 disabled:bg-gray-50 disabled:text-gray-500"
+          readOnly={!isEditable}
+          className="w-32 rounded border border-gray-300 px-2 py-1 text-right text-sm font-mono focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500 disabled:bg-gray-50 disabled:text-gray-500 read-only:bg-gray-50 read-only:text-gray-500"
           step="0.01"
         />
       </div>

--- a/packages/client/src/pages/fnf/FnFDetailPage.tsx
+++ b/packages/client/src/pages/fnf/FnFDetailPage.tsx
@@ -142,7 +142,8 @@ export function FnFDetailPage() {
 
   const isPaid = fnf?.status === "paid";
   const isApproved = fnf?.status === "approved";
-  const isEditable = !isPaid;
+  // Once approved or paid, the settlement is locked — amounts shouldn't change.
+  const isEditable = !isPaid && !isApproved;
 
   const handleCalculate = async () => {
     if (!exitId) return;

--- a/packages/client/src/pages/interviews/InterviewDetailPage.tsx
+++ b/packages/client/src/pages/interviews/InterviewDetailPage.tsx
@@ -186,7 +186,7 @@ export function InterviewDetailPage() {
         );
 
       case "multiple_choice": {
-        const options = q.options ? q.options.split(",").map((o) => o.trim()) : [];
+        const options = q.options ? q.options.split(",").map((o) => o.trim()).filter(Boolean) : [];
         return (
           <div className="space-y-2">
             {options.map((opt) => (
@@ -375,7 +375,7 @@ export function InterviewDetailPage() {
               <div className="flex-1">
                 <p className="font-medium text-gray-900">
                   {q.question_text}
-                  {q.is_required && <span className="ml-1 text-red-500">*</span>}
+                  {Boolean(Number(q.is_required)) && <span className="ml-1 text-red-500">*</span>}
                 </p>
                 <div className="mt-3">{renderQuestionInput(q)}</div>
               </div>

--- a/packages/client/src/pages/interviews/InterviewDetailPage.tsx
+++ b/packages/client/src/pages/interviews/InterviewDetailPage.tsx
@@ -354,6 +354,16 @@ export function InterviewDetailPage() {
         )}
       </div>
 
+      {/* A completed/skipped interview with no recorded answers — make it
+          explicit instead of showing a blank, fillable-looking form. */}
+      {isReadOnly && (!interview.responses || interview.responses.length === 0) && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+          {isSkipped
+            ? "This interview was skipped — no responses were recorded."
+            : "This interview is marked completed, but no responses were recorded."}
+        </div>
+      )}
+
       {/* Questions */}
       <div className="space-y-4">
         {questions.map((q, idx) => (

--- a/packages/client/src/pages/interviews/InterviewDetailPage.tsx
+++ b/packages/client/src/pages/interviews/InterviewDetailPage.tsx
@@ -22,6 +22,7 @@ import type {
 
 interface InterviewDetail extends ExitInterview {
   responses: (ExitInterviewResponse & { question?: ExitInterviewQuestion })[];
+  interviewer?: { first_name: string; last_name: string; designation: string | null } | null;
 }
 
 interface TemplateWithQuestions extends ExitInterviewTemplate {
@@ -348,7 +349,9 @@ export function InterviewDetailPage() {
             <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Interviewer</p>
             <p className="mt-1 text-sm font-medium text-gray-900 flex items-center gap-1">
               <User className="h-4 w-4 text-gray-400" />
-              ID: {interview.interviewer_id}
+              {interview.interviewer
+                ? `${interview.interviewer.first_name} ${interview.interviewer.last_name}`
+                : `ID: ${interview.interviewer_id}`}
             </p>
           </div>
         )}

--- a/packages/client/src/pages/interviews/InterviewListPage.tsx
+++ b/packages/client/src/pages/interviews/InterviewListPage.tsx
@@ -21,7 +21,16 @@ interface InterviewListItem {
   status: string;
   overall_rating: number | null;
   created_at: string;
+  exit_status: string | null;
+  employee?: { first_name: string; last_name: string; designation: string | null } | null;
 }
+
+const STATUS_FILTERS = [
+  { value: "", label: "All Statuses" },
+  { value: "scheduled", label: "Scheduled" },
+  { value: "completed", label: "Completed" },
+  { value: "skipped", label: "Skipped" },
+];
 
 const STATUS_CONFIG: Record<string, { bg: string; label: string; icon: React.ReactNode }> = {
   scheduled: {
@@ -45,18 +54,21 @@ export function InterviewListPage() {
   const navigate = useNavigate();
   const [interviews, setInterviews] = useState<InterviewListItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState("");
 
   const fetchInterviews = useCallback(async () => {
+    setLoading(true);
     try {
-      // The API gets interview per exit, so we fetch from a general list
-      // For now we show a placeholder with navigation to detail pages
-      setInterviews([]);
+      const params: Record<string, any> = {};
+      if (statusFilter) params.status = statusFilter;
+      const res = await apiGet<InterviewListItem[]>("/interviews/list", params);
+      setInterviews(res.data ?? []);
     } catch {
-      // silently handle
+      setInterviews([]);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [statusFilter]);
 
   useEffect(() => {
     fetchInterviews();
@@ -92,50 +104,97 @@ export function InterviewListPage() {
         </button>
       </div>
 
-      {/* Info card */}
-      <div className="rounded-lg border border-gray-200 bg-white p-8">
-        <div className="text-center">
-          <MessageSquare className="mx-auto h-12 w-12 text-gray-300" />
-          <h3 className="mt-4 text-sm font-medium text-gray-900">
-            Exit interviews are managed per exit request
-          </h3>
-          <p className="mt-2 text-sm text-gray-500 max-w-md mx-auto">
-            Navigate to an exit request detail page and go to the interview tab to schedule,
-            conduct, or review exit interviews. Use the templates page to manage question
-            templates.
-          </p>
-          <div className="mt-6 flex items-center justify-center gap-3">
-            <button
-              onClick={() => navigate("/exits")}
-              className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors"
-            >
-              View Exits
-            </button>
-            <button
-              onClick={() => navigate("/interviews/templates")}
-              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-            >
-              Manage Templates
-            </button>
-          </div>
-        </div>
-
-        {/* Status legend */}
-        <div className="mt-8 flex items-center justify-center gap-6">
-          {Object.entries(STATUS_CONFIG).map(([key, cfg]) => (
-            <span
-              key={key}
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium",
-                cfg.bg,
-              )}
-            >
-              {cfg.icon}
-              {cfg.label}
-            </span>
+      {/* Filter */}
+      <div className="flex items-center gap-3">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+        >
+          {STATUS_FILTERS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
           ))}
-        </div>
+        </select>
+        <span className="text-sm text-gray-500">
+          {interviews.length} interview{interviews.length === 1 ? "" : "s"}
+        </span>
       </div>
+
+      {/* List */}
+      {interviews.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-10 text-center">
+          <MessageSquare className="mx-auto h-12 w-12 text-gray-300" />
+          <h3 className="mt-4 text-sm font-medium text-gray-900">No exit interviews yet</h3>
+          <p className="mt-2 mx-auto max-w-md text-sm text-gray-500">
+            Interviews are scheduled from an exit request. Open an exit and use its Interview tab to
+            schedule one.
+          </p>
+          <button
+            onClick={() => navigate("/exits")}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors"
+          >
+            View Exits
+          </button>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Employee</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Scheduled</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Rating</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                <th className="px-6 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {interviews.map((iv) => {
+                const cfg = STATUS_CONFIG[iv.status] || STATUS_CONFIG.scheduled;
+                const name = iv.employee
+                  ? `${iv.employee.first_name} ${iv.employee.last_name}`
+                  : "—";
+                return (
+                  <tr key={iv.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4">
+                      <p className="text-sm font-medium text-gray-900">{name}</p>
+                      {iv.employee?.designation && (
+                        <p className="text-xs text-gray-500">{iv.employee.designation}</p>
+                      )}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-600">
+                      {iv.scheduled_date ? formatDate(iv.scheduled_date) : "—"}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-600">
+                      {iv.overall_rating != null ? `${iv.overall_rating}/10` : "—"}
+                    </td>
+                    <td className="px-6 py-4">
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
+                          cfg.bg,
+                        )}
+                      >
+                        {cfg.icon}
+                        {cfg.label}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-right">
+                      <button
+                        onClick={() => navigate(`/interviews/${iv.exit_request_id}`)}
+                        className="inline-flex items-center gap-1 text-sm font-medium text-rose-600 hover:text-rose-700"
+                      >
+                        <Eye className="h-4 w-4" />
+                        View
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/pages/interviews/InterviewTemplatesPage.tsx
+++ b/packages/client/src/pages/interviews/InterviewTemplatesPage.tsx
@@ -33,6 +33,16 @@ interface TemplateWithQuestions extends ExitInterviewTemplate {
   questions: ExitInterviewQuestion[];
 }
 
+// Normalize a comma-separated options string: trim each value and drop blanks,
+// so a stray trailing comma (e.g. "a, b,") doesn't create an empty option.
+function cleanOptions(raw: string): string {
+  return raw
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean)
+    .join(",");
+}
+
 export function InterviewTemplatesPage() {
   const [templates, setTemplates] = useState<ExitInterviewTemplate[]>([]);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -151,7 +161,7 @@ export function InterviewTemplatesPage() {
       await apiPost(`/interviews/templates/${expandedId}/questions`, {
         question_text: qText.trim(),
         question_type: qType,
-        options: qType === "multiple_choice" ? qOptions.trim() : undefined,
+        options: qType === "multiple_choice" ? cleanOptions(qOptions) : undefined,
         is_required: qRequired,
       });
       resetQuestionForm();
@@ -167,7 +177,7 @@ export function InterviewTemplatesPage() {
       await apiPut(`/interviews/templates/${expandedId}/questions/${editingQuestionId}`, {
         question_text: qText.trim(),
         question_type: qType,
-        options: qType === "multiple_choice" ? qOptions.trim() : undefined,
+        options: qType === "multiple_choice" ? cleanOptions(qOptions) : undefined,
         is_required: qRequired,
       });
       resetQuestionForm();

--- a/packages/client/src/pages/interviews/MyExitInterviewPage.tsx
+++ b/packages/client/src/pages/interviews/MyExitInterviewPage.tsx
@@ -173,7 +173,7 @@ export function MyExitInterviewPage() {
         );
 
       case "multiple_choice": {
-        const options = q.options ? q.options.split(",").map((o) => o.trim()) : [];
+        const options = q.options ? q.options.split(",").map((o) => o.trim()).filter(Boolean) : [];
         return (
           <div className="space-y-2">
             {options.map((opt) => (
@@ -322,7 +322,7 @@ export function MyExitInterviewPage() {
               <div className="flex-1">
                 <p className="font-medium text-gray-900 text-base">
                   {q.question_text}
-                  {q.is_required && <span className="ml-1 text-red-500">*</span>}
+                  {Boolean(Number(q.is_required)) && <span className="ml-1 text-red-500">*</span>}
                 </p>
                 <div className="mt-4">{renderQuestionInput(q)}</div>
               </div>

--- a/packages/client/src/pages/kt/KTListPage.tsx
+++ b/packages/client/src/pages/kt/KTListPage.tsx
@@ -20,6 +20,18 @@ const KT_STATUS: Record<string, { label: string; color: string }> = {
   completed: { label: "Completed", color: "bg-green-100 text-green-700" },
 };
 
+// Exit lifecycle status → readable label (the picker otherwise showed raw
+// values like "fnf_processed" / "notice_period").
+const EXIT_STATUS_LABELS: Record<string, string> = {
+  initiated: "Initiated",
+  notice_period: "Notice Period",
+  clearance_pending: "Clearance Pending",
+  fnf_pending: "FnF Pending",
+  fnf_processed: "FnF Processed",
+  completed: "Completed",
+  cancelled: "Cancelled",
+};
+
 interface ExitOption {
   id: string;
   status: string;
@@ -225,14 +237,14 @@ export function KTListPage() {
                         </p>
                       </div>
                       <span className={cn(
-                        "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium capitalize",
+                        "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
                         exit.status === "completed"
                           ? "bg-green-100 text-green-700"
                           : exit.status === "active"
                           ? "bg-blue-100 text-blue-700"
                           : "bg-gray-100 text-gray-700",
                       )}>
-                        {exit.status}
+                        {EXIT_STATUS_LABELS[exit.status] || exit.status}
                       </span>
                     </button>
                   </li>

--- a/packages/client/src/routes.tsx
+++ b/packages/client/src/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Route, Navigate } from "react-router-dom";
+import { Route, Navigate, useParams } from "react-router-dom";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
 import { isAdmin, EMPLOYEE_HOME } from "@/lib/auth-store";
 
@@ -7,6 +7,13 @@ import { isAdmin, EMPLOYEE_HOME } from "@/lib/auth-store";
 // instead of seeing an org-wide management console (or an empty, role-scoped one).
 function AdminRoute({ children }: { children: React.ReactNode }) {
   return isAdmin() ? <>{children}</> : <Navigate to={EMPLOYEE_HOME} replace />;
+}
+
+// /exits/:id/resignation has no dedicated page — the resignation details live on
+// the exit detail page. Redirect there (preserving the id) instead of 404-ing.
+function ExitResignationRedirect() {
+  const { id } = useParams<{ id: string }>();
+  return <Navigate to={`/exits/${id}`} replace />;
 }
 
 // Lazy-loaded pages
@@ -159,6 +166,7 @@ export function AppRoutes() {
         <Route path="/exits/new" element={<AdminRoute><InitiateExitPage /></AdminRoute>} />
         <Route path="/exits/resign" element={<ResignationPage />} />
         <Route path="/exits/my" element={<MyExitPage />} />
+        <Route path="/exits/:id/resignation" element={<ExitResignationRedirect />} />
         <Route path="/exits/:id" element={<AdminRoute><ExitDetailPage /></AdminRoute>} />
 
         {/* Checklists */}

--- a/packages/client/src/routes.tsx
+++ b/packages/client/src/routes.tsx
@@ -168,6 +168,8 @@ export function AppRoutes() {
         {/* Clearance */}
         <Route path="/clearance" element={<AdminRoute><ClearanceRecordsPage /></AdminRoute>} />
         <Route path="/clearance/departments" element={<AdminRoute><ClearanceDeptPage /></AdminRoute>} />
+        {/* Alias so a /clearance/dept deep-link doesn't 404. */}
+        <Route path="/clearance/dept" element={<Navigate to="/clearance/departments" replace />} />
 
         {/* Interviews */}
         <Route path="/interviews" element={<AdminRoute><InterviewListPage /></AdminRoute>} />

--- a/packages/server/src/api/routes/interview.routes.ts
+++ b/packages/server/src/api/routes/interview.routes.ts
@@ -160,6 +160,24 @@ router.delete(
 // Exit interview routes (per exit request)
 // ---------------------------------------------------------------------------
 
+// GET /list — all exit interviews for the org (admin management view).
+// (Mounted at /list because GET / is the templates alias.)
+router.get(
+  "/list",
+  authorize("org_admin", "hr_admin", "hr_manager"),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.user!.empcloudOrgId;
+      const interviews = await interviewService.listInterviews(orgId, {
+        status: req.query.status as string | undefined,
+      });
+      sendSuccess(res, interviews);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // GET /exit/:exitId — get interview for an exit request
 router.get(
   "/exit/:exitId",

--- a/packages/server/src/services/analytics/flight-risk.service.ts
+++ b/packages/server/src/services/analytics/flight-risk.service.ts
@@ -578,11 +578,15 @@ export async function getFlightRiskDashboard(orgId: number): Promise<DashboardSu
     riskLevel: scoreToRiskLevel(Math.round(Number(r.avg_score))),
   }));
 
+  // Count the factors driving risk across anyone who is at least moderately at
+  // risk (score >= 40, factor impact >= 40). The previous thresholds (>= 60 on
+  // both) meant "Top Risk Factor" stayed N/A unless someone crossed the high-
+  // risk line, even when the team had real elevated risk.
   const allFactorsRaw = await db.raw<any>(
     `SELECT factors
      FROM flight_risk_scores
      WHERE organization_id = ?
-       AND score >= 60`,
+       AND score >= 40`,
     [orgId],
   );
   const allFactorsData =
@@ -595,7 +599,7 @@ export async function getFlightRiskDashboard(orgId: number): Promise<DashboardSu
     const factors: RiskFactor[] =
       typeof row.factors === "string" ? JSON.parse(row.factors) : row.factors || [];
     for (const f of factors) {
-      if (f.impact >= 60) {
+      if (f.impact >= 40) {
         factorCounts[f.name] = (factorCounts[f.name] || 0) + 1;
       }
     }

--- a/packages/server/src/services/buyout/notice-buyout.service.ts
+++ b/packages/server/src/services/buyout/notice-buyout.service.ts
@@ -6,7 +6,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { getDB } from "../../db/adapters";
-import { findUserById } from "../../db/empcloud";
+import { findUserById, getEmpCloudDB } from "../../db/empcloud";
 import { NotFoundError, ValidationError, ConflictError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 import type { ExitRequest, NoticeBuyoutRequest } from "@emp-exit/shared";
@@ -269,8 +269,24 @@ export async function listBuyoutRequests(
       : { field: "created_at", order: "desc" },
   });
 
+  // Enrich with employee names from empcloud (the list otherwise shows
+  // "Employee #<id>"). employee_id lives directly on the buyout row.
+  const empDb = getEmpCloudDB();
+  const employeeIds = [
+    ...new Set(
+      result.data.map((b) => b.employee_id).filter((id): id is number => typeof id === "number"),
+    ),
+  ];
+  const empMap = new Map<number, any>();
+  if (employeeIds.length > 0) {
+    const employees = await empDb("users")
+      .whereIn("id", employeeIds)
+      .select("id", "first_name", "last_name", "email", "emp_code", "designation");
+    for (const e of employees) empMap.set(e.id, e);
+  }
+
   return {
-    data: result.data,
+    data: result.data.map((b) => ({ ...b, employee: empMap.get(b.employee_id) ?? null })),
     total: result.total,
     page: result.page,
     perPage: result.limit,

--- a/packages/server/src/services/fnf/fnf.service.ts
+++ b/packages/server/src/services/fnf/fnf.service.ts
@@ -252,8 +252,8 @@ export async function updateFnF(
   });
   if (!fnf) throw new NotFoundError("FnF settlement for exit", exitRequestId);
 
-  if (fnf.status === "paid") {
-    throw new ConflictError("Cannot update a paid FnF settlement");
+  if (fnf.status === "paid" || fnf.status === "approved") {
+    throw new ConflictError(`Cannot update a ${fnf.status} FnF settlement`);
   }
 
   // Recalculate total

--- a/packages/server/src/services/interview/exit-interview.service.ts
+++ b/packages/server/src/services/interview/exit-interview.service.ts
@@ -5,6 +5,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { getDB } from "../../db/adapters";
+import { getEmpCloudDB } from "../../db/empcloud";
 import { NotFoundError, ValidationError, ConflictError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 import { InterviewStatus } from "@emp-exit/shared";
@@ -287,6 +288,62 @@ export async function getInterview(
   );
 
   return { ...interview, responses };
+}
+
+/**
+ * List all exit interviews for the org, enriched with the employee and the
+ * exit's status, so the Interviews page can show a real list instead of a
+ * placeholder. Optional status filter.
+ */
+export async function listInterviews(
+  orgId: number,
+  params: { status?: string } = {},
+): Promise<any[]> {
+  const db = getDB();
+
+  // Interviews are scoped to the org via their exit request.
+  const exitsResult = await db.findMany<any>("exit_requests", {
+    filters: { organization_id: orgId },
+    limit: 1000,
+  });
+  const exitById = new Map(exitsResult.data.map((e) => [e.id, e]));
+  const exitIds = exitsResult.data.map((e) => e.id);
+  if (exitIds.length === 0) return [];
+
+  const filters: Record<string, any> = { exit_request_id: exitIds };
+  if (params.status) filters.status = params.status;
+
+  const interviews = await db.findMany<ExitInterview>("exit_interviews", {
+    filters,
+    sort: { field: "created_at", order: "desc" },
+    limit: 1000,
+  });
+
+  // Enrich with employee details from EmpCloud.
+  const empDb = getEmpCloudDB();
+  const employeeIds = [
+    ...new Set(
+      interviews.data
+        .map((i) => exitById.get(i.exit_request_id)?.employee_id)
+        .filter((id): id is number => typeof id === "number"),
+    ),
+  ];
+  const empMap = new Map<number, any>();
+  if (employeeIds.length > 0) {
+    const employees = await empDb("users")
+      .whereIn("id", employeeIds)
+      .select("id", "first_name", "last_name", "designation");
+    for (const e of employees) empMap.set(e.id, e);
+  }
+
+  return interviews.data.map((i) => {
+    const exit = exitById.get(i.exit_request_id);
+    return {
+      ...i,
+      exit_status: exit?.status ?? null,
+      employee: exit ? empMap.get(exit.employee_id) ?? null : null,
+    };
+  });
 }
 
 export async function submitResponses(

--- a/packages/server/src/services/interview/exit-interview.service.ts
+++ b/packages/server/src/services/interview/exit-interview.service.ts
@@ -259,7 +259,13 @@ export async function scheduleInterview(
 export async function getInterview(
   orgId: number,
   exitRequestId: string,
-): Promise<(ExitInterview & { responses: (ExitInterviewResponse & { question?: ExitInterviewQuestion })[] }) | null> {
+): Promise<
+  | (ExitInterview & {
+      responses: (ExitInterviewResponse & { question?: ExitInterviewQuestion })[];
+      interviewer: { id: number; first_name: string; last_name: string; designation: string | null } | null;
+    })
+  | null
+> {
   const db = getDB();
 
   // Verify exit request belongs to org
@@ -287,7 +293,18 @@ export async function getInterview(
     }),
   );
 
-  return { ...interview, responses };
+  // Resolve the interviewer to a name (the UI otherwise shows "ID: <n>").
+  let interviewer = null;
+  if (interview.interviewer_id) {
+    const empDb = getEmpCloudDB();
+    interviewer =
+      (await empDb("users")
+        .where({ id: interview.interviewer_id })
+        .select("id", "first_name", "last_name", "designation")
+        .first()) ?? null;
+  }
+
+  return { ...interview, interviewer, responses };
 }
 
 /**


### PR DESCRIPTION
Polishes three admin pages that showed placeholder or developer-facing content.

== Interviews page (was a placeholder) ==

The Exit Interviews page rendered a static "managed per exit request" card with no list â€” its fetch was a stub that returned an empty array, and there was no list-all endpoint on the backend.

- Add GET /interviews/list (admin-gated) returning all exit interviews for the org, each enriched with the employee's name/designation and the exit's status, with an optional ?status filter. Mounted at /list because GET / is already the templates alias.
- InterviewListPage now renders a real table (Employee, Scheduled date, Rating, Status) with a status filter, a count, and a graceful empty state. Each row links to the interview detail (/interviews/{exit_request_id}).

== FnF "Calculation Details" (raw JSON) ==

The FnF detail page dumped the raw breakdown_json via JSON.stringify â€” snake_case keys (last_basic_salary, lwd, notice_start_date), ISO timestamps, and 0/1 booleans.

- Render it as a friendly label/value list: known keys get human labels and typed formatting (money as INR, dates formatted, notice as "30 days", booleans as Yes/No). Unknown keys still display, so nothing is hidden; invalid JSON shows a clean fallback message.

== Interview detail: empty completed interview ==

A completed interview with no recorded responses showed a blank, fillable-looking form (no indication that nothing was answered).

- Add an explicit banner when a completed/skipped interview has no responses: "This interview is marked completed, but no responses were recorded" (or "was skipped"). When responses exist, they render read-only as before.

== Testing ==

- Client and server typecheck clean.
- Verified GET /interviews/list against an org_admin token: returns interviews with employee names + ratings, status filter works, and an employee token gets 403.
- Confirmed the interview detail pre-fills and displays existing responses read-only when present; the new banner shows only when there are none.
