### PR TITLE
feat(exit): edit KT plan successor and due date

### DIFF
--- a/packages/client/src/pages/kt/KTListPage.tsx
+++ b/packages/client/src/pages/kt/KTListPage.tsx
@@ -9,6 +9,8 @@ import {
   Loader2,
   FileText,
   User,
+  Search,
+  ChevronRight,
 } from "lucide-react";
 import { apiGet, apiPost, apiPut } from "@/api/client";
 import toast from "react-hot-toast";
@@ -19,6 +21,21 @@ const KT_STATUS: Record<string, { label: string; color: string }> = {
   in_progress: { label: "In Progress", color: "bg-blue-100 text-blue-700" },
   completed: { label: "Completed", color: "bg-green-100 text-green-700" },
 };
+
+// Exit lifecycle status → badge colour + readable label.
+const EXIT_STATUS: Record<string, { label: string; color: string }> = {
+  initiated: { label: "Initiated", color: "bg-blue-100 text-blue-700" },
+  notice_period: { label: "Notice Period", color: "bg-amber-100 text-amber-700" },
+  clearance_pending: { label: "Clearance Pending", color: "bg-orange-100 text-orange-700" },
+  fnf_pending: { label: "FnF Pending", color: "bg-purple-100 text-purple-700" },
+  fnf_processed: { label: "FnF Processed", color: "bg-indigo-100 text-indigo-700" },
+  completed: { label: "Completed", color: "bg-green-100 text-green-700" },
+  cancelled: { label: "Cancelled", color: "bg-gray-100 text-gray-500" },
+};
+
+function initials(first?: string, last?: string): string {
+  return `${(first?.[0] || "").toUpperCase()}${(last?.[0] || "").toUpperCase()}` || "?";
+}
 
 interface ExitOption {
   id: string;
@@ -42,6 +59,7 @@ export function KTListPage() {
   // hint and there's no in-UI way to proceed.
   const [exitOptions, setExitOptions] = useState<ExitOption[]>([]);
   const [loadingExits, setLoadingExits] = useState(false);
+  const [exitSearch, setExitSearch] = useState("");
   useEffect(() => {
     if (exitId) return;
     let cancelled = false;
@@ -185,63 +203,99 @@ export function KTListPage() {
       </div>
 
       {/* Exit picker — shown only when no exit is selected via the URL.
-          Clicking a row sets ?exitId=... and the rest of the page renders
-          the KT plan / items for that exit. */}
-      {!exitId && (
-        <div className="rounded-lg border border-gray-200 bg-white">
-          <div className="border-b border-gray-100 px-4 py-3">
-            <h2 className="text-sm font-semibold text-gray-900">Select an exit</h2>
-            <p className="mt-0.5 text-xs text-gray-500">
-              Pick the exit you want to manage knowledge transfer for.
-            </p>
-          </div>
-          {loadingExits ? (
-            <div className="flex h-32 items-center justify-center">
-              <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+          Clicking a card sets ?exitId=... and the rest of the page renders
+          the KT plan / items for that exit. Cancelled exits are hidden since
+          KT can't meaningfully run on them. */}
+      {!exitId && (() => {
+        // Hide cancelled exits, then apply the search filter.
+        const visible = exitOptions
+          .filter((e) => e.status !== "cancelled")
+          .filter((e) => {
+            if (!exitSearch.trim()) return true;
+            const q = exitSearch.toLowerCase();
+            const name = `${e.employee?.first_name ?? ""} ${e.employee?.last_name ?? ""}`.toLowerCase();
+            return (
+              name.includes(q) ||
+              (e.employee?.emp_code ?? "").toLowerCase().includes(q) ||
+              (e.employee?.designation ?? "").toLowerCase().includes(q)
+            );
+          });
+
+        return (
+          <div className="space-y-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-gray-900">Select an exit</h2>
+                <p className="mt-0.5 text-sm text-gray-500">
+                  Pick the exit you want to manage knowledge transfer for.
+                </p>
+              </div>
+              <div className="relative w-full sm:w-72">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                <input
+                  value={exitSearch}
+                  onChange={(e) => setExitSearch(e.target.value)}
+                  placeholder="Search by name, code, designation…"
+                  className="w-full rounded-lg border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+                />
+              </div>
             </div>
-          ) : exitOptions.length === 0 ? (
-            <p className="px-4 py-8 text-center text-sm text-gray-500">
-              No exits found. Initiate an exit first to manage its KT plan.
-            </p>
-          ) : (
-            <ul className="divide-y divide-gray-100">
-              {exitOptions.map((exit) => {
-                const name = exit.employee
-                  ? `${exit.employee.first_name} ${exit.employee.last_name}`
-                  : "(unknown employee)";
-                return (
-                  <li key={exit.id}>
+
+            {loadingExits ? (
+              <div className="flex h-40 items-center justify-center rounded-xl border border-gray-200 bg-white">
+                <Loader2 className="h-6 w-6 animate-spin text-rose-500" />
+              </div>
+            ) : visible.length === 0 ? (
+              <div className="rounded-xl border border-gray-200 bg-white p-10 text-center">
+                <BookOpen className="mx-auto h-10 w-10 text-gray-300" />
+                <p className="mt-3 text-sm text-gray-500">
+                  {exitSearch
+                    ? "No exits match your search."
+                    : "No active exits found. Initiate an exit first to manage its KT plan."}
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {visible.map((exit) => {
+                  const name = exit.employee
+                    ? `${exit.employee.first_name} ${exit.employee.last_name}`
+                    : "Unknown employee";
+                  const st = EXIT_STATUS[exit.status] || { label: exit.status, color: "bg-gray-100 text-gray-600" };
+                  return (
                     <button
+                      key={exit.id}
                       type="button"
                       onClick={() => selectExit(exit.id)}
-                      className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-rose-50"
+                      className="group flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 text-left shadow-sm transition-all hover:border-rose-200 hover:shadow-md"
                     >
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-gray-900">{name}</p>
-                        <p className="truncate text-xs text-gray-500">
-                          {exit.employee?.emp_code ? `${exit.employee.emp_code} · ` : ""}
-                          {exit.exit_type.replace(/_/g, " ")}
-                          {exit.last_working_date ? ` · LWD ${formatDate(exit.last_working_date)}` : ""}
-                        </p>
+                      <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-rose-100 text-sm font-semibold text-rose-700">
+                        {initials(exit.employee?.first_name, exit.employee?.last_name)}
                       </div>
-                      <span className={cn(
-                        "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium capitalize",
-                        exit.status === "completed"
-                          ? "bg-green-100 text-green-700"
-                          : exit.status === "active"
-                          ? "bg-blue-100 text-blue-700"
-                          : "bg-gray-100 text-gray-700",
-                      )}>
-                        {exit.status}
-                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-semibold text-gray-900">{name}</p>
+                        {exit.employee?.designation && (
+                          <p className="truncate text-xs text-gray-500">{exit.employee.designation}</p>
+                        )}
+                        <div className="mt-1.5 flex items-center gap-2">
+                          <span className={cn("rounded-full px-2 py-0.5 text-[11px] font-medium", st.color)}>
+                            {st.label}
+                          </span>
+                          {exit.last_working_date && (
+                            <span className="text-[11px] text-gray-400">
+                              LWD {formatDate(exit.last_working_date)}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors group-hover:text-rose-500" />
                     </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      )}
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       {loading ? (
         <div className="flex h-32 items-center justify-center">

--- a/packages/client/src/pages/kt/KTListPage.tsx
+++ b/packages/client/src/pages/kt/KTListPage.tsx
@@ -11,6 +11,7 @@ import {
   User,
   Search,
   ChevronRight,
+  Pencil,
 } from "lucide-react";
 import { apiGet, apiPost, apiPut } from "@/api/client";
 import toast from "react-hot-toast";
@@ -89,6 +90,12 @@ export function KTListPage() {
   const [submitting, setSubmitting] = useState(false);
   const [creating, setCreating] = useState(false);
 
+  // Edit-plan form (successor + due date)
+  const [editingPlan, setEditingPlan] = useState(false);
+  const [planForm, setPlanForm] = useState({ assignee_id: "", due_date: "" });
+  const [savingPlan, setSavingPlan] = useState(false);
+  const [employees, setEmployees] = useState<{ id: number; first_name: string; last_name: string; emp_code: string | null }[]>([]);
+
   async function fetchKT() {
     if (!exitId) return;
     setLoading(true);
@@ -104,6 +111,23 @@ export function KTListPage() {
 
   useEffect(() => {
     fetchKT();
+  }, [exitId]);
+
+  // Load the org's active employees once an exit is selected, so the successor
+  // name (not a raw ID) shows on the plan and the edit dropdown is ready.
+  useEffect(() => {
+    if (!exitId || employees.length > 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiGet<any>("/users", { limit: 200 });
+        const list = res.data?.data ?? res.data ?? [];
+        if (!cancelled) setEmployees(Array.isArray(list) ? list : []);
+      } catch {
+        /* successor will fall back to ID */
+      }
+    })();
+    return () => { cancelled = true; };
   }, [exitId]);
 
   async function handleCreateKT() {
@@ -135,6 +159,43 @@ export function KTListPage() {
       toast.error(err.response?.data?.error?.message || "Failed to complete KT plan");
     } finally {
       setCompletingPlan(false);
+    }
+  }
+
+  async function openEditPlan() {
+    setPlanForm({
+      assignee_id: kt?.assignee_id ? String(kt.assignee_id) : "",
+      due_date: kt?.due_date ? String(kt.due_date).slice(0, 10) : "",
+    });
+    setEditingPlan(true);
+    // Load active employees for the successor dropdown (once).
+    if (employees.length === 0) {
+      try {
+        const res = await apiGet<any>("/users", { limit: 200 });
+        const list = res.data?.data ?? res.data ?? [];
+        setEmployees(Array.isArray(list) ? list : []);
+      } catch {
+        setEmployees([]);
+      }
+    }
+  }
+
+  async function handleSavePlan(e: React.FormEvent) {
+    e.preventDefault();
+    if (!exitId) return;
+    setSavingPlan(true);
+    try {
+      await apiPut(`/kt/exit/${exitId}`, {
+        assignee_id: planForm.assignee_id ? Number(planForm.assignee_id) : null,
+        due_date: planForm.due_date || null,
+      });
+      toast.success("KT plan updated");
+      setEditingPlan(false);
+      fetchKT();
+    } catch (err: any) {
+      toast.error(err.response?.data?.error?.message || "Failed to update KT plan");
+    } finally {
+      setSavingPlan(false);
     }
   }
 
@@ -338,21 +399,85 @@ export function KTListPage() {
                     </button>
                   );
                 })()}
+                {kt.status !== "completed" && !editingPlan && (
+                  <button
+                    type="button"
+                    onClick={openEditPlan}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                    Edit
+                  </button>
+                )}
                 <span className={cn("rounded-full px-3 py-1 text-xs font-medium", KT_STATUS[kt.status]?.color || KT_STATUS.not_started.color)}>
                   {KT_STATUS[kt.status]?.label || kt.status}
                 </span>
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4 text-sm">
-              <div className="flex items-center gap-2 text-gray-600">
-                <User className="h-4 w-4" />
-                <span>Successor ID: {kt.assignee_id || "Not assigned"}</span>
+
+            {editingPlan ? (
+              <form onSubmit={handleSavePlan} className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-700">Successor</label>
+                  <select
+                    value={planForm.assignee_id}
+                    onChange={(e) => setPlanForm((f) => ({ ...f, assignee_id: e.target.value }))}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+                  >
+                    <option value="">Not assigned</option>
+                    {employees.map((emp) => (
+                      <option key={emp.id} value={emp.id}>
+                        {emp.first_name} {emp.last_name}{emp.emp_code ? ` (${emp.emp_code})` : ""}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-700">Due date</label>
+                  <input
+                    type="date"
+                    value={planForm.due_date}
+                    onChange={(e) => setPlanForm((f) => ({ ...f, due_date: e.target.value }))}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+                  />
+                </div>
+                <div className="flex gap-3 sm:col-span-2">
+                  <button
+                    type="submit"
+                    disabled={savingPlan}
+                    className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+                  >
+                    {savingPlan && <Loader2 className="h-4 w-4 animate-spin" />}
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditingPlan(false)}
+                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="flex items-center gap-2 text-gray-600">
+                  <User className="h-4 w-4" />
+                  <span>
+                    Successor:{" "}
+                    {(() => {
+                      const s = employees.find((e) => e.id === kt.assignee_id);
+                      if (s) return `${s.first_name} ${s.last_name}`;
+                      return kt.assignee_id ? `ID ${kt.assignee_id}` : "Not assigned";
+                    })()}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-gray-600">
+                  <Clock className="h-4 w-4" />
+                  <span>Due: {kt.due_date ? formatDate(kt.due_date) : "Not set"}</span>
+                </div>
               </div>
-              <div className="flex items-center gap-2 text-gray-600">
-                <Clock className="h-4 w-4" />
-                <span>Due: {kt.due_date ? formatDate(kt.due_date) : "Not set"}</span>
-              </div>
-            </div>
+            )}
           </div>
 
           {/* Add item form */}

--- a/packages/server/src/services/kt/knowledge-transfer.service.ts
+++ b/packages/server/src/services/kt/knowledge-transfer.service.ts
@@ -65,7 +65,7 @@ export async function getKT(orgId: number, exitRequestId: string) {
 export async function updateKT(
   orgId: number,
   exitRequestId: string,
-  data: { assignee_id?: number; status?: string },
+  data: { assignee_id?: number | null; due_date?: string | null; status?: string },
 ) {
   const db = getDB();
 
@@ -85,7 +85,8 @@ export async function updateKT(
   }
 
   const updateData: Record<string, any> = {};
-  if (data.assignee_id !== undefined) updateData.assignee_id = data.assignee_id;
+  if (data.assignee_id !== undefined) updateData.assignee_id = data.assignee_id || null;
+  if (data.due_date !== undefined) updateData.due_date = data.due_date || null;
   if (data.status !== undefined) {
     updateData.status = data.status;
     if (data.status === "completed") {


### PR DESCRIPTION
Adds the ability to set a KT plan's successor and due date.

The KT plan card showed "Successor: Not assigned" and "Due: Not set" with no way to change them â€” only items could be added.

Changes:
- Edit button on the KT Plan card (hidden once the plan is completed) opens an inline form:
  - Successor: a dropdown of the org's active employees (GET /users) â€” no raw IDs.
  - Due date: a date picker.
  Saving PUTs to /kt/exit/:exitId.
- The read-only view now resolves and shows the successor's name instead of the raw assignee ID.
- Backend: updateKT now accepts due_date (previously only assignee_id/status), and empty assignee_id/due_date are stored as null so they can be cleared.

NOTE: stacked on PR #37 (the KT exit-picker redesign), since both touch KTListPage.tsx. This PR's diff includes #37's commit until that merges; review/merge #37 first, then this.

Testing: client + server typecheck clean; verified set/clear of successor and due date round-trips via the API.
